### PR TITLE
During testing reset PIO namelist values to 1 PIO task

### DIFF
--- a/testing/testing_utils.py
+++ b/testing/testing_utils.py
@@ -159,6 +159,15 @@ def create_new_namelist(filenameIn, filenameOut, nmlPatch):
     f90nml.patch(filenameIn, nmlPatch, filenameOut)
 
 #-------------------------------------------------------------------------
+
+def add_pio_namelist_changes(nmlChanges, nProcs):
+
+    nmlChanges["io"] = {"config_pio_num_iotasks":1,
+                        "config_pio_stride":nProcs}
+
+    return nmlChanges
+
+#-------------------------------------------------------------------------
 # streams manupulation
 #-------------------------------------------------------------------------
 

--- a/testing/tests/parallelism.py
+++ b/testing/tests/parallelism.py
@@ -47,6 +47,7 @@ def parallelism(mpasDevelopmentDir,
     nmlChanges = {"seaice_model": {"config_run_duration":'24:00:00'}}
     if (check):
         nmlChanges["unit_test"] = {"config_testing_system_test":True}
+    nmlChanges = add_pio_namelist_changes(nmlChanges, nProcs)
 
     streamChanges = [{"streamName":"restart", "attributeName":"output_interval", "newValue":"24:00:00"}, \
                      {"streamName":"output" , "attributeName":"output_interval", "newValue":"none"}]
@@ -80,6 +81,7 @@ def parallelism(mpasDevelopmentDir,
 
     if (check):
         nmlChanges["unit_test"] = {"config_testing_system_test":True}
+    nmlChanges = add_pio_namelist_changes(nmlChanges, nProcs)
 
     streamChanges = [{"streamName":"restart", "attributeName":"output_interval", "newValue":"24:00:00"}, \
                      {"streamName":"output" , "attributeName":"output_interval", "newValue":"none"}]

--- a/testing/tests/regression.py
+++ b/testing/tests/regression.py
@@ -41,6 +41,7 @@ def regression(mpasDevelopmentDir,
     nmlChanges = {"seaice_model": {"config_run_duration":'24:00:00'}}
     if (check):
         nmlChanges["unit_test"] = {"config_testing_system_test":True}
+    nmlChanges = add_pio_namelist_changes(nmlChanges, nProcs)
 
     streamChanges = [{"streamName":"restart", "attributeName":"output_interval", "newValue":"24:00:00"}, \
                      {"streamName":"output" , "attributeName":"output_interval", "newValue":"none"}]
@@ -66,6 +67,8 @@ def regression(mpasDevelopmentDir,
     nmlChanges = {"seaice_model": {"config_run_duration":'24:00:00'}}
     if (check):
         nmlChanges["unit_test"] = {"config_testing_system_test":True}
+    nmlChanges = add_pio_namelist_changes(nmlChanges, nProcs)
+
 
     streamChanges = [{"streamName":"restart", "attributeName":"output_interval", "newValue":"24:00:00"}, \
                      {"streamName":"output" , "attributeName":"output_interval", "newValue":"none"}]

--- a/testing/tests/restartability.py
+++ b/testing/tests/restartability.py
@@ -39,6 +39,7 @@ def restartability(mpasDevelopmentDir,
     nmlChanges = {"seaice_model": {"config_run_duration":'24:00:00'}}
     if (check):
         nmlChanges["unit_test"] = {"config_testing_system_test":True}
+    nmlChanges = add_pio_namelist_changes(nmlChanges, nProcs)
 
     streamChanges = [{"streamName":"restart", "attributeName":"output_interval", "newValue":"24:00:00"}, \
                      {"streamName":"output" , "attributeName":"output_interval", "newValue":"none"}]
@@ -64,6 +65,7 @@ def restartability(mpasDevelopmentDir,
     nmlChanges = {"seaice_model": {"config_run_duration":'12:00:00'}}
     if (check):
         nmlChanges["unit_test"] = {"config_testing_system_test":True}
+    nmlChanges = add_pio_namelist_changes(nmlChanges, nProcs)
 
     streamChanges = [{"streamName":"restart", "attributeName":"output_interval", "newValue":"12:00:00"}, \
                      {"streamName":"output" , "attributeName":"output_interval", "newValue":"none"}]
@@ -111,6 +113,7 @@ def restartability(mpasDevelopmentDir,
 
     if (check):
         nmlChanges["unit_test"] = {"config_testing_system_test":True}
+    nmlChanges = add_pio_namelist_changes(nmlChanges, nProcs)
 
     streamChanges = []
 


### PR DESCRIPTION
Set config_pio_num_iotasks to 1 and config_pio_stride to nProcs for model execution in the testing system. Before on UNM machine Wheeler model execution would take an incredibly long time.