### PR TITLE
Remove advection test from code in MPAS-Seaice-MPM

### DIFF
--- a/configurations/aerosol_shortwave_physics/namelist.seaice
+++ b/configurations/aerosol_shortwave_physics/namelist.seaice
@@ -121,7 +121,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/configurations/icepack_standard_physics_single_cell/namelist.seaice
+++ b/configurations/icepack_standard_physics_single_cell/namelist.seaice
@@ -121,7 +121,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/configurations/prescribed_ice/namelist.seaice
+++ b/configurations/prescribed_ice/namelist.seaice
@@ -120,7 +120,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/configurations/snicar_shortwave/namelist.seaice
+++ b/configurations/snicar_shortwave/namelist.seaice
@@ -121,7 +121,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/configurations/snicar_shortwave_single_cell/namelist.seaice
+++ b/configurations/snicar_shortwave_single_cell/namelist.seaice
@@ -121,7 +121,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/configurations/snow_tracer_physics/namelist.seaice
+++ b/configurations/snow_tracer_physics/namelist.seaice
@@ -121,7 +121,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/configurations/standard_bgc/namelist.seaice
+++ b/configurations/standard_bgc/namelist.seaice
@@ -121,7 +121,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/configurations/standard_physics/namelist.seaice
+++ b/configurations/standard_physics/namelist.seaice
@@ -121,7 +121,6 @@
     config_mpm_particle_posn_init_type = 'xyprojection'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 4096
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/configurations/standard_physics_mpm/namelist.seaice
+++ b/configurations/standard_physics_mpm/namelist.seaice
@@ -121,7 +121,6 @@
     config_mpm_particle_posn_init_type = 'xyprojection'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 4096
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/configurations/standard_physics_single_cell/namelist.seaice
+++ b/configurations/standard_physics_single_cell/namelist.seaice
@@ -121,7 +121,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/MPM/advection/add_deldyn_to_ics.py
+++ b/testcases/MPM/advection/add_deldyn_to_ics.py
@@ -1,0 +1,55 @@
+import argparse
+from netCDF4 import Dataset
+import os
+
+#--------------------------------------------------------------------
+
+def add_deldyn_to_ics(dynamicsTimeStep):
+
+    reses = ["2562","10242","40962","163842"]
+
+    icTypes = ["cosine_bell","slotted_cylinder"]
+
+    for icType in icTypes:
+
+        print("icType: ", icType)
+
+        for res in reses:
+
+            print("  Res: ", res)
+
+            icFilename = "ic_%s_%s.nc" %(icType, res)
+
+            if (not os.path.isfile(icFilename)):
+                raise Exception("IC file missing: "+icFilename)
+
+            filein = Dataset(icFilename,"a")
+
+            uVelocity = filein.variables["uVelocity"][:]
+            vVelocity = filein.variables["vVelocity"][:]
+
+            try:
+                filein.createDimension("TWO",2)
+            except:
+                pass
+
+            try:
+                deluDyn = filein.createVariable("deluDyn","d",dimensions=["nVertices","TWO"])
+            except:
+                deluDyn = filein.variables["deluDyn"][:]
+            deluDyn[:,0] = uVelocity[:] * dynamicsTimeStep
+            deluDyn[:,1] = vVelocity[:] * dynamicsTimeStep
+
+            filein.close()
+
+#--------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-d', dest='dynamicsTimeStep', type=float)
+
+    args = parser.parse_args()
+
+    add_deldyn_to_ics(args.dynamicsTimeStep)

--- a/testcases/MPM/advection/check_particles_moved.py
+++ b/testcases/MPM/advection/check_particles_moved.py
@@ -1,0 +1,75 @@
+from netCDF4 import Dataset
+import numpy as np
+import argparse
+
+#------------------------------------------------------------------
+
+def set_globalID(creationIndexMP,cellIDCreationMP):
+
+    return (creationIndexMP << 32) + cellIDCreationMP
+
+#-------------------------------------------------------------------------------
+
+def check_particles_moved(particleFile0,
+                          particleFile1):
+
+    file1 = Dataset(particleFile0,"r")
+    file2 = Dataset(particleFile1,"r")
+
+    nParticles1 = len(file1.dimensions["nParticles"])
+    nParticles2 = len(file2.dimensions["nParticles"])
+
+    statusMP1 = file1.variables["statusMP"][0,:]
+    statusMP2 = file2.variables["statusMP"][0,:]
+    nParticlesStatus1 = np.count_nonzero(statusMP1)
+    nParticlesStatus2 = np.count_nonzero(statusMP2)
+
+    creationIndexMP1  = file1.variables["creationIndexMP"][0,:]
+    cellIDCreationMP1 = file1.variables["cellIDCreationMP"][0,:]
+
+    creationIndexMP2  = file2.variables["creationIndexMP"][0,:]
+    cellIDCreationMP2 = file2.variables["cellIDCreationMP"][0,:]
+
+    posnMP0 = file1.variables["posnMP"][:]
+    posnMP1 = file2.variables["posnMP"][:]
+
+    file1.close()
+    file2.close()
+
+    globalID1 = []
+    globalID2 = []
+    for iParticle in range(0,nParticles1):
+        if (statusMP1[iParticle] == 1):
+            globalID = set_globalID(creationIndexMP1[iParticle],cellIDCreationMP1[iParticle])
+            globalID1.append(globalID)
+    for iParticle in range(0,nParticles2):
+        if (statusMP2[iParticle] == 1):
+            globalID = set_globalID(creationIndexMP2[iParticle],cellIDCreationMP2[iParticle])
+            globalID2.append(globalID)
+    globalID1 = np.array(globalID1)
+    globalID2 = np.array(globalID2)
+    particlesOrder1 = np.argsort(globalID1)
+    particlesOrder2 = np.argsort(globalID2)
+
+    posnMP0 = posnMP0[0,(statusMP1 == 1)][particlesOrder1]
+    posnMP1 = posnMP1[0,(statusMP2 == 1)][particlesOrder2]
+
+    if (posnMP0.shape != posnMP1.shape):
+        raise Exception("check_particles_moved: posnMP0.shape != posnMP1.shape")
+
+    if (np.array_equal(posnMP0,posnMP1)):
+        raise Exception("check_particles_moved: Particles did not apparently move: "+particleFile0+" to "+particleFile1)
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--p0', dest='particleFile0', required=True)
+    parser.add_argument('--p1', dest='particleFile1', required=True)
+
+    args = parser.parse_args()
+
+    check_particles_moved(args.particleFile0,
+                          args.particleFile1)

--- a/testcases/MPM/advection/namelist.seaice
+++ b/testcases/MPM/advection/namelist.seaice
@@ -120,7 +120,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 128
-    config_mpm_advection_test = true
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/MPM/advection/run_testcase.py
+++ b/testcases/MPM/advection/run_testcase.py
@@ -3,6 +3,7 @@ import sys
 sys.path.append("../../advection")
 from get_testcase_data import get_testcase_data
 from create_ics import create_ics
+from add_deldyn_to_ics import add_deldyn_to_ics
 from create_particles import create_particles
 
 sys.path.append("./graphs")
@@ -11,14 +12,20 @@ from create_graph_file_metis import create_graph_file_metis
 
 from check_particle_positions_start_end import check_particle_positions_start_end
 from check_particle_positions_nprocs import check_particle_positions_nprocs
+from check_particles_moved import check_particles_moved
 from run_model import run_model
 import os
 
 nCells = 2562
 
+particleFilename1 = "particles_output.2000-01-01_00.00.00.nc"
+particleFilename2 = "particles_output.2000-03-01_00.00.00.nc"
+
 get_testcase_data()
 
 create_ics()
+
+add_deldyn_to_ics(3600.0)
 
 create_particles()
 
@@ -29,18 +36,28 @@ create_graph_file_metis(nCells, 16)
 create_graph_file_metis(nCells, 32)
 
 run_model(nCells, 1)
+check_particles_moved("./output_1/"+particleFilename1,
+                      "./output_1/"+particleFilename2)
 
 check_particle_positions_start_end("./output_1/particles*")
 
 run_model(nCells, 2)
+check_particles_moved("./output_2/"+particleFilename1,
+                      "./output_2/"+particleFilename2)
 check_particle_positions_nprocs(2,1)
 
 run_model(nCells, 4)
+check_particles_moved("./output_4/"+particleFilename1,
+                      "./output_4/"+particleFilename2)
 check_particle_positions_nprocs(4,1)
 
 run_model(nCells, 16)
+check_particles_moved("./output_16/"+particleFilename1,
+                      "./output_16/"+particleFilename2)
 check_particle_positions_nprocs(16,1)
 
 run_model(nCells, 32)
+check_particles_moved("./output_32/"+particleFilename1,
+                      "./output_32/"+particleFilename2)
 check_particle_positions_nprocs(32,1)
 check_particle_positions_nprocs(32,16)

--- a/testcases/MPM/advection/streams.seaice
+++ b/testcases/MPM/advection/streams.seaice
@@ -23,6 +23,7 @@
 
         <var name="uVelocity"/>
         <var name="vVelocity"/>
+        <var name="deluDyn"/>
 	<var name="iceAreaCell"/>
 	<var name="iceVolumeCell"/>
 	<var name="iceAreaCategory"/>

--- a/testcases/MPM/advection_convergence/advection_equatorial.py
+++ b/testcases/MPM/advection_convergence/advection_equatorial.py
@@ -3,6 +3,8 @@ import math
 import matplotlib.pyplot as plt
 import numpy as np
 import matplotlib as mpl
+import glob
+from average_particle_ice_area_to_cell import average_particle_ice_area_to_cell
 
 #---------------------------------------------------------
 
@@ -90,7 +92,7 @@ def advection_equatorial():
 
     iTime = -1
 
-    # cosine bell
+    # mesh
     filename = "./output_%s_%s/output.2000.nc" %(experiment1,res)
 
     print(filename)
@@ -108,58 +110,28 @@ def advection_equatorial():
     cellsOnCell = fileMPAS.variables["cellsOnCell"][:]
     nEdgesOnCell = fileMPAS.variables["nEdgesOnCell"][:]
 
-    iceArea_CB_Initial   = fileMPAS.variables["iceAreaCell"][0,:]
-    iceVolume_CB_Initial = fileMPAS.variables["iceVolumeCell"][0,:]
-    iceThickness_CB_Initial = np.zeros(nCells)
-    for iCell in range(0,nCells):
-        if (iceArea_CB_Initial[iCell] > 0.0):
-            iceThickness_CB_Initial[iCell] = iceVolume_CB_Initial[iCell] / iceArea_CB_Initial[iCell]
-
-    iceArea_CB = fileMPAS.variables["iceAreaCell"][iTime,:]
-    iceVolume_CB = fileMPAS.variables["iceVolumeCell"][iTime,:]
-    iceThickness_CB = np.zeros(nCells)
-    for iCell in range(0,nCells):
-        if (iceArea_CB[iCell] > 0.0):
-            iceThickness_CB[iCell] = iceVolume_CB[iCell] / iceArea_CB[iCell]
-
     fileMPAS.close()
+
+    # cosine bell
+    filenamesParticleCB = sorted(glob.glob("./output_%s_%s/particles_output*" %(experiment1,res)))
+
+    iceArea_CB_Initial = average_particle_ice_area_to_cell(filenamesParticleCB[ 0], nCells)
+    iceArea_CB         = average_particle_ice_area_to_cell(filenamesParticleCB[-1], nCells)
 
     # slotted cylinder
-    filename = "./output_%s_%s/output.2000.nc" %(experiment2,res)
+    filenamesParticleSC = sorted(glob.glob("./output_%s_%s/particles_output*" %(experiment2,res)))
 
-    print(filename)
-    fileMPAS = Dataset(filename,"r")
+    iceArea_SC_Initial = average_particle_ice_area_to_cell(filenamesParticleSC[ 0], nCells)
+    iceArea_SC         = average_particle_ice_area_to_cell(filenamesParticleSC[-1], nCells)
 
-    iceArea_SC_Initial   = fileMPAS.variables["iceAreaCell"][0,:]
-    iceVolume_SC_Initial = fileMPAS.variables["iceVolumeCell"][0,:]
-    iceThickness_SC_Initial = np.zeros(nCells)
-    for iCell in range(0,nCells):
-        if (iceArea_SC_Initial[iCell] > 0.0):
-            iceThickness_SC_Initial[iCell] = iceVolume_SC_Initial[iCell] / iceArea_SC_Initial[iCell]
-
-    iceArea_SC = fileMPAS.variables["iceAreaCell"][iTime,:]
-    iceVolume_SC = fileMPAS.variables["iceVolumeCell"][iTime,:]
-    iceThickness_SC = np.zeros(nCells)
-    for iCell in range(0,nCells):
-        if (iceArea_SC[iCell] > 0.0):
-            iceThickness_SC[iCell] = iceVolume_SC[iCell] / iceArea_SC[iCell]
-
-    print(np.amin(iceArea_SC_Initial), np.amax(iceArea_SC_Initial), np.amin(iceVolume_SC_Initial), np.amax(iceVolume_SC_Initial))
-    print(np.amin(iceArea_SC), np.amax(iceArea_SC), np.amin(iceVolume_SC), np.amax(iceVolume_SC))
-
-    fileMPAS.close()
+    print(np.amin(iceArea_SC_Initial), np.amax(iceArea_SC_Initial))
+    print(np.amin(iceArea_SC),         np.amax(iceArea_SC))
 
     lons, yiceArea_CB_Initial = get_equatorial_array(nCells, latCell, lonCell, xCell, yCell, zCell, cellsOnCell, nEdgesOnCell, iceArea_CB_Initial)
     lons, yiceArea_CB = get_equatorial_array(nCells, latCell, lonCell, xCell, yCell, zCell, cellsOnCell, nEdgesOnCell, iceArea_CB)
 
     lons, yiceArea_SC_Initial = get_equatorial_array(nCells, latCell, lonCell, xCell, yCell, zCell, cellsOnCell, nEdgesOnCell, iceArea_SC_Initial)
     lons, yiceArea_SC = get_equatorial_array(nCells, latCell, lonCell, xCell, yCell, zCell, cellsOnCell, nEdgesOnCell, iceArea_SC)
-
-    lons, yiceThickness_CB_Initial = get_equatorial_array(nCells, latCell, lonCell, xCell, yCell, zCell, cellsOnCell, nEdgesOnCell, iceThickness_CB_Initial)
-    lons, yiceThickness_CB = get_equatorial_array(nCells, latCell, lonCell, xCell, yCell, zCell, cellsOnCell, nEdgesOnCell, iceThickness_CB)
-
-    lons, yiceThickness_SC_Initial = get_equatorial_array(nCells, latCell, lonCell, xCell, yCell, zCell, cellsOnCell, nEdgesOnCell, iceThickness_SC_Initial)
-    lons, yiceThickness_SC = get_equatorial_array(nCells, latCell, lonCell, xCell, yCell, zCell, cellsOnCell, nEdgesOnCell, iceThickness_SC)
 
     cm = 1/2.54  # centimeters in inches
     plt.rcParams["font.family"] = "Times New Roman"

--- a/testcases/MPM/advection_convergence/advection_error_convergence.py
+++ b/testcases/MPM/advection_convergence/advection_error_convergence.py
@@ -3,6 +3,8 @@ import math
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 import numpy as np
+import glob
+from average_particle_ice_area_to_cell import average_particle_ice_area_to_cell
 
 #--------------------------------------------------------
 
@@ -23,53 +25,22 @@ def L2_norm(numerical, analytical, nPoints, areaCell):
 
 #--------------------------------------------------------
 
-def get_norm_area(filename):
+def get_norm_area(filenameMesh, filenameParticlesTemplate):
 
-    fileMPAS = Dataset(filename, "r")
+    fileMPAS = Dataset(filenameMesh, "r")
 
     nCells = len(fileMPAS.dimensions["nCells"])
 
     areaCell = fileMPAS.variables["areaCell"][:]
 
-    iceAreaCell = fileMPAS.variables["iceAreaCell"][:]
+    fileMPAS.close()
 
-    iceAreaCellInitial = iceAreaCell[0,:]
-    iceAreaCellFinal   = iceAreaCell[-1,:]
+    filenamesParticle = sorted(glob.glob(filenameParticlesTemplate))
+
+    iceAreaCellInitial = average_particle_ice_area_to_cell(filenamesParticle[ 0], nCells)
+    iceAreaCellFinal   = average_particle_ice_area_to_cell(filenamesParticle[-1], nCells)
 
     norm = L2_norm(iceAreaCellFinal, iceAreaCellInitial, nCells, areaCell)
-
-    fileMPAS.close()
-
-    return norm
-
-#--------------------------------------------------------
-
-def get_norm_thickness(filename):
-
-    fileMPAS = Dataset(filename, "r")
-
-    nCells = len(fileMPAS.dimensions["nCells"])
-
-    areaCell = fileMPAS.variables["areaCell"][:]
-
-    iceAreaCategoryInitial = fileMPAS.variables["iceAreaCategory"][0,:,0,0]
-    iceAreaCategoryFinal   = fileMPAS.variables["iceAreaCategory"][-1,:,0,0]
-
-    iceVolumeCategoryInitial = fileMPAS.variables["iceVolumeCategory"][0,:,0,0]
-    iceVolumeCategoryFinal   = fileMPAS.variables["iceVolumeCategory"][-1,:,0,0]
-
-    iceThicknessCategoryInitial = np.zeros(nCells)
-    iceThicknessCategoryFinal   = np.zeros(nCells)
-
-    for iCell in range(0,nCells):
-        if (iceAreaCategoryInitial[iCell] > 0.0):
-            iceThicknessCategoryInitial[iCell] = iceVolumeCategoryInitial[iCell] / iceAreaCategoryInitial[iCell]
-        if (iceAreaCategoryFinal[iCell] > 0.0):
-            iceThicknessCategoryFinal[iCell] = iceVolumeCategoryFinal[iCell] / iceAreaCategoryFinal[iCell]
-
-    norm = L2_norm(iceThicknessCategoryFinal, iceThicknessCategoryInitial, nCells, areaCell)
-
-    fileMPAS.close()
 
     return norm
 
@@ -163,20 +134,14 @@ def advection_error_convergence():
          xArea = []
          yArea = []
 
-         xVolume = []
-         yVolume = []
-
          for resolution in resolutions:
 
              filename = "./output_%s_%i/output.2000.nc" %(experiment,resolution)
+             filenameParticlesTemplate = "./output_%s_%i/particles_output*" %(experiment,resolution)
 
-             norm = get_norm_area(filename)
+             norm = get_norm_area(filename, filenameParticlesTemplate)
              xArea.append(get_resolution(filename))
              yArea.append(norm)
-
-             norm = get_norm_thickness(filename)
-             xVolume.append(get_resolution(filename))
-             yVolume.append(norm)
 
          error = float('nan')
          print(xArea, yArea)

--- a/testcases/MPM/advection_convergence/advection_map.py
+++ b/testcases/MPM/advection_convergence/advection_map.py
@@ -8,6 +8,8 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 import math, sys
 from scipy.interpolate import griddata
 from matplotlib.ticker import FormatStrFormatter
+import glob
+from average_particle_ice_area_to_cell import average_particle_ice_area_to_cell
 
 #---------------------------------------------------------------
 
@@ -176,8 +178,8 @@ def advection_map():
 
     print("Load data...")
 
-    # slotted cylinder
-    filename    = "./output_%s_%s/output.2000.nc" %(experiment2,res)
+    # mesh
+    filename = "./output_%s_%s/output.2000.nc" %(experiment2,res)
 
     file = Dataset(filename, "r")
 
@@ -195,20 +197,19 @@ def advection_map():
     yCell          = file.variables["yCell"][:]
     zCell          = file.variables["zCell"][:]
 
-    iceAreaInitialSC   = file.variables["iceAreaCell"][0,:]
-    iceAreaSC   = file.variables["iceAreaCell"][iTime,:]
-
     file.close()
+
+    # slotted cylinder
+    filenamesParticleSC = sorted(glob.glob("./output_%s_%s/particles_output*" %(experiment2,res)))
+
+    iceAreaInitialSC = average_particle_ice_area_to_cell(filenamesParticleSC[ 0], nCells)
+    iceAreaSC        = average_particle_ice_area_to_cell(filenamesParticleSC[-1], nCells)
 
     # cosine bell
-    filename = "./output_%s_%s/output.2000.nc" %(experiment1,res)
+    filenamesParticleCB = sorted(glob.glob("./output_%s_%s/particles_output*" %(experiment1,res)))
 
-    file = Dataset(filename, "r")
-
-    iceAreaInitialCB   = file.variables["iceAreaCell"][0,:]
-    iceAreaCB   = file.variables["iceAreaCell"][iTime,:]
-
-    file.close()
+    iceAreaInitialCB = average_particle_ice_area_to_cell(filenamesParticleCB[ 0], nCells)
+    iceAreaCB        = average_particle_ice_area_to_cell(filenamesParticleCB[-1], nCells)
 
     scaleFactor = 0.9
     #scaleFactor = 1.0

--- a/testcases/MPM/advection_convergence/average_particle_ice_area_to_cell.py
+++ b/testcases/MPM/advection_convergence/average_particle_ice_area_to_cell.py
@@ -1,0 +1,33 @@
+from netCDF4 import Dataset
+import numpy as np
+
+#---------------------------------------------------------
+
+def average_particle_ice_area_to_cell(filenameParticles, nCells):
+
+    filein = Dataset(filenameParticles,"r")
+
+    nParticles = len(filein.dimensions["nParticles"])
+
+    statusMP      = filein.variables["statusMP"][0,:]
+    iCellMP       = filein.variables["iCellMP"][0,:]-1
+    iceAreaCellMP = filein.variables["iceAreaCellMP"][0,:]
+
+    filein.close()
+
+    iceAreaCell = np.zeros(nCells)
+    nParticlesCell = np.zeros(nCells)
+
+    for iParticle in range(0,nParticles):
+        if (statusMP[iParticle] == 1):
+            iCell = iCellMP[iParticle]
+            iceAreaCell[iCell] += iceAreaCellMP[iParticle]
+            nParticlesCell[iCell] += 1.0
+
+    for iCell in range(0,nCells):
+        if (nParticlesCell[iCell] > 0.0):
+            iceAreaCell[iCell] /= nParticlesCell[iCell]
+
+    return iceAreaCell
+
+#---------------------------------------------------------

--- a/testcases/MPM/advection_convergence/namelist.seaice
+++ b/testcases/MPM/advection_convergence/namelist.seaice
@@ -120,7 +120,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 128
-    config_mpm_advection_test = true
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/MPM/advection_convergence/plot_testcase.py
+++ b/testcases/MPM/advection_convergence/plot_testcase.py
@@ -6,6 +6,8 @@ from matplotlib.collections import PatchCollection
 import matplotlib.cm as cm
 import numpy as np
 import os
+from average_particle_ice_area_to_cell import average_particle_ice_area_to_cell
+import glob
 
 #-------------------------------------------------------------
 
@@ -89,37 +91,71 @@ def plot_testcase():
 
                 print("  Test type: ", testType)
 
+                # mesh
+                filenamein = "./output_%s_%i/output.2000.nc" %(testType,nGrid)
+
+                filein = Dataset(filenamein,"r")
+
+                nCells = len(filein.dimensions["nCells"])
+
+                nEdgesOnCell = filein.variables["nEdgesOnCell"][:]
+                verticesOnCell = filein.variables["verticesOnCell"][:]
+                xCell = filein.variables["xCell"][:]
+                yCell = filein.variables["yCell"][:]
+                zCell = filein.variables["zCell"][:]
+                xVertex = filein.variables["xVertex"][:]
+                yVertex = filein.variables["yVertex"][:]
+                zVertex = filein.variables["zVertex"][:]
+                verticesOnCell[:] = verticesOnCell[:] - 1
+
+                filein.close()
+
+                # iceArea
+                filenameParticlesTemplate = "./output_%s_%i/particles_output*" %(testType,nGrid)
+                filenames = sorted(glob.glob(filenameParticlesTemplate))
+
+                iceAreaCell0 = average_particle_ice_area_to_cell(filenames[0], nCells)
+
                 iMethod = -1
                 for iTime in iTimes:
                     iMethod +=1
 
                     print("iTime: ", iTime)
 
-                    filenamein = "./output_%s_%i/output.2000.nc" %(testType,nGrid)
+                    iceAreaCell = average_particle_ice_area_to_cell(filenames[iTime], nCells)
 
-                    filein = Dataset(filenamein,"r")
+                    plot_subfigure(axes[iMethod,iTestType*2],
+                                   iceAreaCell,
+                                   nCells,
+                                   nEdgesOnCell,
+                                   verticesOnCell,
+                                   xCell,
+                                   yCell,
+                                   zCell,
+                                   xVertex,
+                                   yVertex,
+                                   zVertex,
+                                   0.0,
+                                   1.0,
+                                   "viridis")
 
-                    nCells = len(filein.dimensions["nCells"])
+                    iceAreaCellDiff = iceAreaCell - iceAreaCell0
 
-                    nEdgesOnCell = filein.variables["nEdgesOnCell"][:]
-                    verticesOnCell = filein.variables["verticesOnCell"][:]
-                    xCell = filein.variables["xCell"][:]
-                    yCell = filein.variables["yCell"][:]
-                    zCell = filein.variables["zCell"][:]
-                    xVertex = filein.variables["xVertex"][:]
-                    yVertex = filein.variables["yVertex"][:]
-                    zVertex = filein.variables["zVertex"][:]
-                    verticesOnCell[:] = verticesOnCell[:] - 1
-                    iceAreaCell = filein.variables["iceAreaCell"][:]
-
-                    filein.close()
-
-                    plot_subfigure(axes[iMethod,iTestType*2], iceAreaCell[iTime], nCells, nEdgesOnCell, verticesOnCell, xCell, yCell, zCell, xVertex, yVertex, zVertex, 0.0, 1.0, "viridis")
-
-                    iceAreaCellDiff = iceAreaCell[iTime] - iceAreaCell[0]
-
-                    if (iMethod !=0):
-                        plot_subfigure(axes[iMethod,iTestType*2+1], iceAreaCellDiff, nCells, nEdgesOnCell, verticesOnCell, xCell, yCell, zCell, xVertex, yVertex, zVertex, -1.0, 1.0, "bwr")
+                    if (iMethod != 0):
+                        plot_subfigure(axes[iMethod,iTestType*2+1],
+                                       iceAreaCellDiff,
+                                       nCells,
+                                       nEdgesOnCell,
+                                       verticesOnCell,
+                                       xCell,
+                                       yCell,
+                                       zCell,
+                                       xVertex,
+                                       yVertex,
+                                       zVertex,
+                                       -1.0,
+                                       1.0,
+                                       "bwr")
                     else:
                         axes[iMethod, iTestType*2+1].axis('off')
 

--- a/testcases/MPM/advection_convergence/run_testcase.py
+++ b/testcases/MPM/advection_convergence/run_testcase.py
@@ -11,13 +11,36 @@ from advection_map import advection_map
 from advection_equatorial import advection_equatorial
 from advection_error_convergence import advection_error_convergence
 
+sys.path.append("../advection")
+from add_deldyn_to_ics import add_deldyn_to_ics
+from check_particles_moved import check_particles_moved
+
+particleFilename1 = "/particles_output.2000-01-01_00.00.00.nc"
+particleFilename2 = "/particles_output.2000-03-01_00.00.00.nc"
+
+outDirs = [
+    "output_cosine_bell_10242",
+    "output_cosine_bell_163842",
+    "output_cosine_bell_2562",
+    "output_cosine_bell_40962",
+    "output_slotted_cylinder_10242",
+    "output_slotted_cylinder_163842",
+    "output_slotted_cylinder_2562",
+    "output_slotted_cylinder_40962"]
+
 get_testcase_data()
 
 create_ics()
 
+add_deldyn_to_ics(3600.0)
+
 create_particles()
 
 run_model()
+
+for outDir in outDirs:
+    check_particles_moved(outDir+particleFilename1,
+                          outDir+particleFilename2)
 
 plot_testcase()
 

--- a/testcases/MPM/advection_convergence/streams.seaice
+++ b/testcases/MPM/advection_convergence/streams.seaice
@@ -27,6 +27,7 @@
 	<var name="iceVolumeCell"/>
 	<var name="iceAreaCategory"/>
 	<var name="iceVolumeCategory"/>
+        <var name="deluDyn"/>
 </stream>
 
 <immutable_stream name="restart"
@@ -48,7 +49,6 @@
 	<var name="daysSinceStartOfSim"/>
 	<stream name="mesh"/>
 	<var name="iceAreaCell"/>
-	<var name="iceAreaVertex"/>
 	<var name="iceVolumeCell"/>
 	<var name="snowVolumeCell"/>
 	<var name="iceAreaCategory"/>
@@ -74,6 +74,7 @@
         <var name="procIDParticle"/>
         <var name="posnMP"/>
         <var name="iceAreaCellMP"/>
+        <var name="deluDyn"/>
 </stream>
 
 <immutable_stream name="LYqSixHourlyForcing"

--- a/testcases/MPM/assembly/namelist.seaice
+++ b/testcases/MPM/assembly/namelist.seaice
@@ -120,7 +120,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = true
     config_mpm_polympo_init_test = false
 /

--- a/testcases/MPM/mpm_tracers/namelist.seaice.default
+++ b/testcases/MPM/mpm_tracers/namelist.seaice.default
@@ -121,7 +121,6 @@
     config_mpm_particle_posn_init_type = 'xyprojection'
     config_mpm_particle_init_number = 1
     config_mpm_particle_block_size = 4096
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/MPM/spherical_operators/interpolation/namelist.seaice
+++ b/testcases/MPM/spherical_operators/interpolation/namelist.seaice
@@ -119,7 +119,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_interpolation_test = true
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false

--- a/testcases/MPM/spherical_operators/reconstruction/namelist.seaice
+++ b/testcases/MPM/spherical_operators/reconstruction/namelist.seaice
@@ -119,7 +119,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/MPM/spherical_operators/strain/namelist.seaice.strain
+++ b/testcases/MPM/spherical_operators/strain/namelist.seaice.strain
@@ -119,7 +119,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/MPM/spherical_operators/strain_stress_divergence/namelist.seaice.strain_stress_divergence
+++ b/testcases/MPM/spherical_operators/strain_stress_divergence/namelist.seaice.strain_stress_divergence
@@ -120,7 +120,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/MPM/square/operators_strain/namelist.seaice.strain
+++ b/testcases/MPM/square/operators_strain/namelist.seaice.strain
@@ -117,7 +117,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
 /
 &column_package

--- a/testcases/MPM/square/operators_strain_stress_divergence/namelist.seaice.strain_stress_divergence
+++ b/testcases/MPM/square/operators_strain_stress_divergence/namelist.seaice.strain_stress_divergence
@@ -117,7 +117,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
 /
 &column_package

--- a/testcases/MPM/standard_physics/namelist.seaice.default
+++ b/testcases/MPM/standard_physics/namelist.seaice.default
@@ -121,7 +121,6 @@
     config_mpm_particle_posn_init_type = 'xyprojection'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 4096
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/advection/namelist.seaice.advection
+++ b/testcases/advection/namelist.seaice.advection
@@ -112,7 +112,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/error_analysis/namelist.seaice.strain
+++ b/testcases/error_analysis/namelist.seaice.strain
@@ -113,7 +113,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/ridging_1D/namelist.seaice.ridging_1D
+++ b/testcases/ridging_1D/namelist.seaice.ridging_1D
@@ -115,7 +115,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/ridging_island/namelist.seaice.ridging_island
+++ b/testcases/ridging_island/namelist.seaice.ridging_island
@@ -113,7 +113,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/simple_shear/namelist.seaice.simple_shear
+++ b/testcases/simple_shear/namelist.seaice.simple_shear
@@ -113,7 +113,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/spherical_operators/strain/namelist.seaice.strain
+++ b/testcases/spherical_operators/strain/namelist.seaice.strain
@@ -120,7 +120,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/spherical_operators/strain_stress_divergence/namelist.seaice.strain_stress_divergence
+++ b/testcases/spherical_operators/strain_stress_divergence/namelist.seaice.strain_stress_divergence
@@ -120,7 +120,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/spherical_operators/stress_divergence/namelist.seaice.stress_divergence
+++ b/testcases/spherical_operators/stress_divergence/namelist.seaice.stress_divergence
@@ -120,7 +120,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/square/operators_strain/namelist.seaice.strain
+++ b/testcases/square/operators_strain/namelist.seaice.strain
@@ -120,7 +120,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/square/operators_strain_stress_divergence/namelist.seaice.strain_stress_divergence
+++ b/testcases/square/operators_strain_stress_divergence/namelist.seaice.strain_stress_divergence
@@ -120,7 +120,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/square/operators_stress_divergence/namelist.seaice.stress_divergence
+++ b/testcases/square/operators_stress_divergence/namelist.seaice.stress_divergence
@@ -120,7 +120,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /

--- a/testcases/square/square_quadhex/namelist.seaice.square
+++ b/testcases/square/square_quadhex/namelist.seaice.square
@@ -113,7 +113,6 @@
     config_mpm_particle_posn_init_type = 'even'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 1024
-    config_mpm_advection_test = false
     config_mpm_assembly_test = false
     config_mpm_polympo_init_test = false
 /


### PR DESCRIPTION
Remove references to the advection test config from namelists 
Add script to add deluDyn to advection test cases initial conditions 
Add script to map particle to cell ice area data for advection convergence test case 
Remove unused code from testing scripts
Add check that particles actually moved in advection test case

Concomitant PR: https://github.com/MPAS-Seaice-MPM-Project/MPAS-Seaice-MPM/pull/69