### PR TITLE
Add full MPM simulation

### DIFF
--- a/configurations/aerosol_shortwave_physics/namelist.seaice
+++ b/configurations/aerosol_shortwave_physics/namelist.seaice
@@ -113,7 +113,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/configurations/icepack_standard_physics_single_cell/namelist.seaice
+++ b/configurations/icepack_standard_physics_single_cell/namelist.seaice
@@ -113,7 +113,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/configurations/prescribed_ice/namelist.seaice
+++ b/configurations/prescribed_ice/namelist.seaice
@@ -112,7 +112,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/configurations/snicar_shortwave/namelist.seaice
+++ b/configurations/snicar_shortwave/namelist.seaice
@@ -113,7 +113,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/configurations/snicar_shortwave_single_cell/namelist.seaice
+++ b/configurations/snicar_shortwave_single_cell/namelist.seaice
@@ -113,7 +113,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/configurations/snow_tracer_physics/namelist.seaice
+++ b/configurations/snow_tracer_physics/namelist.seaice
@@ -113,7 +113,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/configurations/standard_bgc/namelist.seaice
+++ b/configurations/standard_bgc/namelist.seaice
@@ -113,7 +113,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/configurations/standard_physics/namelist.seaice
+++ b/configurations/standard_physics/namelist.seaice
@@ -113,7 +113,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/configurations/standard_physics_mpm/namelist.seaice
+++ b/configurations/standard_physics_mpm/namelist.seaice
@@ -106,16 +106,15 @@
     config_use_special_boundaries_velocity_masks = false
 /
 &advection
-    config_advection_type = 'incremental_remap'
+    config_advection_type = 'mpm'
     config_monotonic = true
     config_conservation_check = false
     config_monotonicity_check = false
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
-    config_use_mpm_freeze_melt = false
+    config_use_mpm_freeze_melt = true
     config_use_mpm_polympo = false
     config_mpm_create_particles = true
     config_mpm_particle_init_type = 'number'
@@ -127,7 +126,7 @@
 /
 &column_package
     config_column_physics_type = 'icepack'
-    config_column_element_type = 'cells'
+    config_column_element_type = 'particles'
     config_use_column_shortwave = true
     config_use_column_vertical_thermodynamics = true
     config_use_column_biogeochemistry = false

--- a/configurations/standard_physics_single_cell/namelist.seaice
+++ b/configurations/standard_physics_single_cell/namelist.seaice
@@ -113,7 +113,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/MPM/advection/namelist.seaice.advection
+++ b/testcases/MPM/advection/namelist.seaice.advection
@@ -105,14 +105,13 @@
     config_use_special_boundaries_velocity_masks = false
 /
 &advection
-    config_advection_type = 'none'
+    config_advection_type = 'mpm'
     config_monotonic = true
     config_conservation_check = false
     config_monotonicity_check = false
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/MPM/advection_convergence/namelist.seaice.advection_convergence
+++ b/testcases/MPM/advection_convergence/namelist.seaice.advection_convergence
@@ -105,14 +105,13 @@
     config_use_special_boundaries_velocity_masks = false
 /
 &advection
-    config_advection_type = 'none'
+    config_advection_type = 'mpm'
     config_monotonic = true
     config_conservation_check = false
     config_monotonicity_check = false
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/MPM/advection_convergence/run_testcase.py
+++ b/testcases/MPM/advection_convergence/run_testcase.py
@@ -51,7 +51,8 @@ def run_testcase(logFilename=None):
     reses = ["2562", "10242", "40962", "163842"]
     icTypes = ["cosine_bell", "slotted_cylinder"]
     DynamicsTimeStep = [3600.0, 1800.0, 900.0, 450.0]
-    usePolympos = [False, True]
+    #usePolympos = [False, True]
+    usePolympos = [False]
 
     print("Get testcase data")
     print("=================")

--- a/testcases/MPM/assembly/namelist.seaice
+++ b/testcases/MPM/assembly/namelist.seaice
@@ -105,14 +105,13 @@
     config_use_special_boundaries_velocity_masks = false
 /
 &advection
-    config_advection_type = 'incremental_remap'
+    config_advection_type = 'mpm'
     config_monotonic = true
     config_conservation_check = false
     config_monotonicity_check = false
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/MPM/column_on_particles/run_testcase.py
+++ b/testcases/MPM/column_on_particles/run_testcase.py
@@ -179,7 +179,6 @@ def run_testcase(nProcs,
     logfile.write("  Modify namelist\n")
     nmlChanges = {"seaice_model":{"config_run_duration":runDuration},
                   "mpm": {"config_use_mpm_velocity_solver":False,
-                          "config_use_mpm_transport":False,
                           "config_use_mpm_freeze_melt":False,
                           "config_mpm_particle_init_type":'cell',
                           "config_mpm_particle_posn_init_type":'cell'},

--- a/testcases/MPM/mpm_tracers/namelist.seaice.default
+++ b/testcases/MPM/mpm_tracers/namelist.seaice.default
@@ -112,7 +112,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_tracers = true
     config_use_mpm_freeze_melt = false

--- a/testcases/MPM/polynya/namelist.seaice.cells
+++ b/testcases/MPM/polynya/namelist.seaice.cells
@@ -113,7 +113,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_tracers = false
     config_use_mpm_polympo = false

--- a/testcases/MPM/polynya/namelist.seaice.particles
+++ b/testcases/MPM/polynya/namelist.seaice.particles
@@ -106,14 +106,13 @@
     config_use_special_boundaries_velocity_masks = false
 /
 &advection
-    config_advection_type = 'none'
+    config_advection_type = 'mpm'
     config_monotonic = true
     config_conservation_check = false
     config_monotonicity_check = false
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_tracers = false
     config_use_mpm_freeze_melt = true

--- a/testcases/MPM/spherical_operators/interpolation/namelist.seaice
+++ b/testcases/MPM/spherical_operators/interpolation/namelist.seaice
@@ -112,9 +112,9 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = false
     config_use_mpm_freeze_melt = false
+    config_use_mpm_polympo = false
     config_mpm_create_particles = false
     config_mpm_particle_init_type = 'number'
     config_mpm_particle_posn_init_type = 'even'

--- a/testcases/MPM/spherical_operators/interpolation/namelist.seaice
+++ b/testcases/MPM/spherical_operators/interpolation/namelist.seaice
@@ -105,7 +105,7 @@
     config_use_special_boundaries_velocity_masks = false
 /
 &advection
-    config_advection_type = 'none'
+    config_advection_type = 'mpm'
     config_monotonic = true
     config_conservation_check = false
     config_monotonicity_check = false

--- a/testcases/MPM/spherical_operators/reconstruction/namelist.seaice
+++ b/testcases/MPM/spherical_operators/reconstruction/namelist.seaice
@@ -112,7 +112,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = false
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_mpm_create_particles = false

--- a/testcases/MPM/spherical_operators/strain/namelist.seaice.strain
+++ b/testcases/MPM/spherical_operators/strain/namelist.seaice.strain
@@ -112,7 +112,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_mpm_create_particles = false

--- a/testcases/MPM/spherical_operators/strain_stress_divergence/namelist.seaice.strain_stress_divergence
+++ b/testcases/MPM/spherical_operators/strain_stress_divergence/namelist.seaice.strain_stress_divergence
@@ -112,7 +112,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/MPM/standard_physics/namelist.seaice.default
+++ b/testcases/MPM/standard_physics/namelist.seaice.default
@@ -113,7 +113,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/advection/namelist.seaice.advection
+++ b/testcases/advection/namelist.seaice.advection
@@ -104,7 +104,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/error_analysis/namelist.seaice.strain
+++ b/testcases/error_analysis/namelist.seaice.strain
@@ -105,7 +105,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/ridging_1D/namelist.seaice.ridging_1D
+++ b/testcases/ridging_1D/namelist.seaice.ridging_1D
@@ -107,7 +107,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/ridging_island/namelist.seaice.ridging_island
+++ b/testcases/ridging_island/namelist.seaice.ridging_island
@@ -105,7 +105,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/simple_shear/namelist.seaice.simple_shear
+++ b/testcases/simple_shear/namelist.seaice.simple_shear
@@ -105,7 +105,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/spherical_operators/strain/namelist.seaice.strain
+++ b/testcases/spherical_operators/strain/namelist.seaice.strain
@@ -112,7 +112,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/spherical_operators/strain_stress_divergence/namelist.seaice.strain_stress_divergence
+++ b/testcases/spherical_operators/strain_stress_divergence/namelist.seaice.strain_stress_divergence
@@ -112,7 +112,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/spherical_operators/stress_divergence/namelist.seaice.stress_divergence
+++ b/testcases/spherical_operators/stress_divergence/namelist.seaice.stress_divergence
@@ -112,7 +112,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/square/operators_strain/namelist.seaice.strain
+++ b/testcases/square/operators_strain/namelist.seaice.strain
@@ -112,7 +112,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/square/operators_strain_stress_divergence/namelist.seaice.strain_stress_divergence
+++ b/testcases/square/operators_strain_stress_divergence/namelist.seaice.strain_stress_divergence
@@ -112,7 +112,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/square/operators_stress_divergence/namelist.seaice.stress_divergence
+++ b/testcases/square/operators_stress_divergence/namelist.seaice.stress_divergence
@@ -112,7 +112,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false

--- a/testcases/square/square_quadhex/namelist.seaice.square
+++ b/testcases/square/square_quadhex/namelist.seaice.square
@@ -105,7 +105,6 @@
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false


### PR DESCRIPTION
Remove config_use_mpm_transport from namelists
Modified standard physics mpm namelist for full MPM simulations 
Modify mpm advection namelists to use advection type mpm

Concomitant PR: https://github.com/MPAS-Seaice-MPM-Project/MPAS-Seaice-MPM/pull/81