### PR TITLE
Improvements to standard mpm configuration

### DIFF
--- a/configurations/standard_physics_mpm/namelist.seaice
+++ b/configurations/standard_physics_mpm/namelist.seaice
@@ -118,7 +118,7 @@
     config_use_mpm_polympo = false
     config_mpm_create_particles = true
     config_mpm_particle_init_type = 'number'
-    config_mpm_particle_posn_init_type = 'xyprojection'
+    config_mpm_particle_posn_init_type = 'reference_equal_area'
     config_mpm_particle_init_number = 9
     config_mpm_particle_block_size = 4096
     config_mpm_assembly_test = false

--- a/configurations/standard_physics_mpm/streams.seaice
+++ b/configurations/standard_physics_mpm/streams.seaice
@@ -21,7 +21,7 @@
         filename_template="output/output.$Y.nc"
         filename_interval="01-00-00_00:00:00"
         clobber_mode="replace_files"
-        output_interval="00-00-01_00:00:00" >
+        output_interval="00-00-00_01:00:00" >
 	<var name="xtime"/>
 	<var name="daysSinceStartOfSim"/>
 	<var name="iceAreaCell"/>
@@ -36,15 +36,19 @@
         filename_template="output/particles_output.$Y-$M-$D_$h.$m.$s.nc"
         filename_interval="00-00-00_00:00:01"
         clobber_mode="replace_files"
-        output_interval="00-00-01_00:00:00" >
-
-   <var name="statusMP"/>
-   <var name="iCellMP"/>
+        output_interval="00-00-00_01:00:00" >
+        <var name="xtime"/>
+        <var name="daysSinceStartOfSim"/>
+        <var name="statusMP"/>
+        <var name="iCellMP"/>
         <var name="cellIDCreationMP"/>
         <var name="creationIndexMP"/>
         <var name="indexToCellIDMP"/>
         <var name="procIDParticle"/>
         <var name="posnMP"/>
+        <var name="iceAreaCellMP"/>
+        <var name="iceVolumeCellMP"/>
+        <var name="snowVolumeCellMP"/>
 </stream>
 
 


### PR DESCRIPTION
Change particle position initialization type to reference_equal_area. This gives more even distribution of initial particles with more consistent areaMP values.
More frequent output and more output fields in output streams