### PR TITLE
Add two new testcases:

### DIFF
--- a/testcases/MPM/advection_time_convergence/advection_equatorial.py
+++ b/testcases/MPM/advection_time_convergence/advection_equatorial.py
@@ -1,0 +1,179 @@
+from netCDF4 import Dataset
+import math
+import matplotlib.pyplot as plt
+import numpy as np
+import matplotlib as mpl
+import glob
+from average_particle_ice_area_to_cell import average_particle_ice_area_to_cell
+
+#---------------------------------------------------------
+
+def get_equatorial_array(nCells, latCell, lonCell, xCell, yCell, zCell, cellsOnCell, nEdgesOnCell, array):
+
+    # find initial point
+    radius = 6371229.0
+    xStart = radius
+    yStart = 0.0
+    zStart = 0.0
+
+    minDistance = 1e30
+    iCellStart = -1
+    for iCell in range(0,nCells):
+
+        distance = math.sqrt(math.pow((xCell[iCell] - xStart),2) + \
+                             math.pow((yCell[iCell] - yStart),2) + \
+                             math.pow((zCell[iCell] - zStart),2))
+
+        if (distance < minDistance):
+            minDistance = distance
+            iCellStart = iCell
+
+
+    iCell = iCellStart
+
+    lats = []
+    lons = []
+    y = []
+    deltaLon = 0.0
+
+    while True:
+
+        lats.append(latCell[iCell])
+        lons.append(lonCell[iCell])
+        y.append(array[iCell])
+
+        iCellNext = -1
+        nextSmallestLatitude = 1e30
+
+        for iCellOnCell in range(0,nEdgesOnCell[iCell]):
+
+            iCellNeighbour = cellsOnCell[iCell,iCellOnCell] - 1
+
+            lonNeighbour = lonCell[iCellNeighbour]
+
+            if (lonNeighbour < lonCell[iCell] - math.pi):
+                lonNeighbour = lonNeighbour + 2.0 * math.pi
+            if (lonNeighbour > lonCell[iCell] + math.pi):
+                lonNeighbour = lonNeighbour - 2.0 * math.pi
+
+            if (lonNeighbour > lonCell[iCell]):
+
+                if (math.fabs(latCell[iCellNeighbour]) < nextSmallestLatitude):
+
+                    nextSmallestLatitude = math.fabs(latCell[iCellNeighbour])
+                    iCellNext = iCellNeighbour
+                    lonNeighbourAll = lonNeighbour
+
+        deltaLon = deltaLon + (lonNeighbourAll - lonCell[iCell])
+
+        if (deltaLon > 2.0 * math.pi):
+            break
+
+        iCell = iCellNext
+
+    points = zip(lons,y)
+    sorted_points = sorted(points)
+    lons = [point[0] for point in sorted_points]
+    y    = [point[1] for point in sorted_points]
+
+    return lons, y
+
+#---------------------------------------------------------
+
+def advection_equatorial(runtype):
+
+    #res = "2562"
+    #res = "10242"
+    #res = "40962"
+    #res = "163842"
+    res = 3600
+
+    experiment1 = "cosine_bell"
+    experiment2 = "slotted_cylinder"
+
+    iTime = -1
+
+    # mesh
+    filename = "./output_%s_%i_%s/output.2000.nc" %(experiment1,res,runtype)
+
+    print(filename)
+    fileMPAS = Dataset(filename,"r")
+
+    nCells = len(fileMPAS.dimensions["nCells"])
+
+    latCell = fileMPAS.variables["latCell"][:]
+    lonCell = fileMPAS.variables["lonCell"][:]
+
+    xCell = fileMPAS.variables["xCell"][:]
+    yCell = fileMPAS.variables["yCell"][:]
+    zCell = fileMPAS.variables["zCell"][:]
+
+    cellsOnCell = fileMPAS.variables["cellsOnCell"][:]
+    nEdgesOnCell = fileMPAS.variables["nEdgesOnCell"][:]
+
+    fileMPAS.close()
+
+    # cosine bell
+    filenamesParticleCB = sorted(glob.glob("./output_%s_%i_%s/particles_output*" %(experiment1,res,runtype)))
+
+    iceArea_CB_Initial = average_particle_ice_area_to_cell(filenamesParticleCB[ 0], nCells)
+    iceArea_CB         = average_particle_ice_area_to_cell(filenamesParticleCB[-1], nCells)
+
+    # slotted cylinder
+    filenamesParticleSC = sorted(glob.glob("./output_%s_%i_%s/particles_output*" %(experiment2,res,runtype)))
+
+    iceArea_SC_Initial = average_particle_ice_area_to_cell(filenamesParticleSC[ 0], nCells)
+    iceArea_SC         = average_particle_ice_area_to_cell(filenamesParticleSC[-1], nCells)
+
+    print(np.amin(iceArea_SC_Initial), np.amax(iceArea_SC_Initial))
+    print(np.amin(iceArea_SC),         np.amax(iceArea_SC))
+
+    lons, yiceArea_CB_Initial = get_equatorial_array(nCells, latCell, lonCell, xCell, yCell, zCell, cellsOnCell, nEdgesOnCell, iceArea_CB_Initial)
+    lons, yiceArea_CB = get_equatorial_array(nCells, latCell, lonCell, xCell, yCell, zCell, cellsOnCell, nEdgesOnCell, iceArea_CB)
+
+    lons, yiceArea_SC_Initial = get_equatorial_array(nCells, latCell, lonCell, xCell, yCell, zCell, cellsOnCell, nEdgesOnCell, iceArea_SC_Initial)
+    lons, yiceArea_SC = get_equatorial_array(nCells, latCell, lonCell, xCell, yCell, zCell, cellsOnCell, nEdgesOnCell, iceArea_SC)
+
+    cm = 1/2.54  # centimeters in inches
+    plt.rcParams["font.family"] = "Times New Roman"
+    SMALL_SIZE = 8
+    MEDIUM_SIZE = 8
+    BIGGER_SIZE = 8
+    plt.rc('font', size=SMALL_SIZE)          # controls default text sizes
+    plt.rc('axes', titlesize=SMALL_SIZE)     # fontsize of the axes title
+    plt.rc('axes', labelsize=MEDIUM_SIZE)    # fontsize of the x and y labels
+    plt.rc('xtick', labelsize=SMALL_SIZE)    # fontsize of the tick labels
+    plt.rc('ytick', labelsize=SMALL_SIZE)    # fontsize of the tick labels
+    plt.rc('legend', fontsize=SMALL_SIZE)    # legend fontsize
+    plt.rc('figure', titlesize=BIGGER_SIZE)  # fontsize of the figure title
+    linewidth = 1.0
+
+    fig, axes = plt.subplots(1, 2, figsize=(15*cm,7*cm))
+
+    # area
+    axes[0].plot(lons, yiceArea_CB_Initial, linewidth=linewidth, color="black", ls="-")
+    axes[0].plot(lons, yiceArea_CB,      linewidth=linewidth, color="red", ls="--")
+
+    axes[0].legend(["Initial","MPM",""],frameon=False,fontsize=8)
+    axes[0].set_xlabel("Longitude (radians)")
+    axes[0].set_ylabel("Equatorial ice concentration")
+
+    axes[0].set_xlim([0.5, math.pi-0.5])
+    axes[0].set_title("(a) Cosine bell", loc='left')
+
+    axes[1].plot(lons, yiceArea_SC_Initial, linewidth=linewidth, color="black", ls="-")
+    axes[1].plot(lons, yiceArea_SC,      linewidth=linewidth, color="red", ls="--")
+
+    axes[1].set_xlabel("Longitude (radians)")
+    axes[1].set_xlim([0.5, math.pi-0.5])
+    axes[1].set_title("(b) Slotted cylinder", loc='left')
+
+    plt.tight_layout(pad=0.2, w_pad=0.6, h_pad=0.2)
+    plt.savefig("advection_equatorial_%s.png" %(runtype),dpi=300)
+    plt.savefig("advection_equatorial_%s.eps" %(runtype))
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    advection_equatorial()

--- a/testcases/MPM/advection_time_convergence/advection_error_convergence.py
+++ b/testcases/MPM/advection_time_convergence/advection_error_convergence.py
@@ -1,0 +1,262 @@
+import sys
+from netCDF4 import Dataset
+import math
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+import numpy as np
+import glob
+from average_particle_ice_area_to_cell import average_particle_ice_area_to_cell
+from check_particle_positions_start_end import check_particle_positions_start_end
+import argparse
+
+#--------------------------------------------------------
+
+def L2_norm(numerical, analytical, nPoints, areaCell):
+
+    norm  = 0.0
+    denom = 0.0
+
+    for iPoint in range(0,nPoints):
+
+        norm  += areaCell[iPoint] * math.pow(numerical[iPoint] - analytical[iPoint],2)
+
+        denom += areaCell[iPoint] * math.pow(analytical[iPoint],2)
+
+    norm = math.sqrt(norm / denom)
+
+    return norm
+
+#--------------------------------------------------------
+
+def get_norm_area(filenameMesh, filenameParticlesTemplate):
+
+    fileMPAS = Dataset(filenameMesh, "r")
+
+    nCells = len(fileMPAS.dimensions["nCells"])
+
+    areaCell = fileMPAS.variables["areaCell"][:]
+
+    fileMPAS.close()
+
+    filenamesParticle = sorted(glob.glob(filenameParticlesTemplate))
+
+    iceAreaCellInitial = average_particle_ice_area_to_cell(filenamesParticle[ 0], nCells)
+    iceAreaCellFinal   = average_particle_ice_area_to_cell(filenamesParticle[-1], nCells)
+
+    norm = L2_norm(iceAreaCellFinal, iceAreaCellInitial, nCells, areaCell)
+
+    return norm
+
+#--------------------------------------------------------
+
+def get_resolution(filename):
+
+    fileMPAS = Dataset(filename, "r")
+
+    nCells = len(fileMPAS.dimensions["nCells"])
+    nEdges = len(fileMPAS.dimensions["nEdges"])
+
+    # mean distance between cells
+    dcEdge = fileMPAS.variables["dcEdge"][:]
+
+    resolution = 0.0
+    for iEdge in range(0,nEdges):
+        resolution = resolution + dcEdge[iEdge]
+
+    resolution = resolution / float(nEdges)
+
+    fileMPAS.close()
+
+    return resolution / 1000.0
+
+#--------------------------------------------------------
+
+def get_grid_size(filename):
+
+    fileMPAS = Dataset(filename, "r")
+
+    nCells = len(fileMPAS.dimensions["nCells"])
+
+    return nCells
+
+#--------------------------------------------------------
+
+def advection_error_convergence(runtype):
+
+    resolutions = [3600, 1800, 900, 450]
+
+    experiments = ["cosine_bell","slotted_cylinder"]
+
+    legendLabels = ["CB", "SC", "", ""]
+
+    markers = ['o','o','^','^']
+    linestyles = ["-", "--", "-", "--"]
+    dashes=[(1,0),(5,2.5),(1,0),(5,2.5)]
+
+    xMin = 450
+    xMax = 3600
+
+    yMin = 3e-2
+    yMax = 1
+
+    scaleArea1 = 0.15 / math.pow(xMax,1)
+    scaleMinArea1 = math.pow(xMin,1) * scaleArea1
+    scaleMaxArea1 = math.pow(xMax,1) * scaleArea1
+
+    scaleArea2 = 0.15 / math.pow(xMax,2)
+    scaleMinArea2 = math.pow(xMin,2) * scaleArea2
+    scaleMaxArea2 = math.pow(xMax,2) * scaleArea2
+
+    scalePos1 = 0.15e4 / math.pow(xMax,1)
+    scaleMinPos1 = math.pow(xMin,1) * scalePos1
+    scaleMaxPos1 = math.pow(xMax,1) * scalePos1
+
+    scalePos2 = 0.15e4 / math.pow(xMax,2)
+    scaleMinPos2 = math.pow(xMin,2) * scalePos2
+    scaleMaxPos2 = math.pow(xMax,2) * scalePos2
+
+
+    scaleThickness = 10e-1 / math.pow(xMin,1)
+
+    scaleMinThickness = math.pow(xMin,1) * scaleThickness
+    scaleMaxThickness = math.pow(xMax,1) * scaleThickness
+
+    #plot
+    cm = 1/2.54  # centimeters in inches
+    plt.rcParams["font.family"] = "Times New Roman"
+    SMALL_SIZE = 8
+    MEDIUM_SIZE = 8
+    BIGGER_SIZE = 8
+    plt.rc('font', size=SMALL_SIZE)          # controls default text sizes
+    plt.rc('axes', titlesize=SMALL_SIZE)     # fontsize of the axes title
+    plt.rc('axes', labelsize=MEDIUM_SIZE)    # fontsize of the x and y labels
+    plt.rc('xtick', labelsize=SMALL_SIZE)    # fontsize of the tick labels
+    plt.rc('ytick', labelsize=SMALL_SIZE)    # fontsize of the tick labels
+    plt.rc('legend', fontsize=SMALL_SIZE)    # legend fontsize
+    plt.rc('figure', titlesize=BIGGER_SIZE)  # fontsize of the figure title
+
+    #positions
+
+    fig, axes = plt.subplots(1, 1, figsize=(8*cm,6.5*cm))
+
+    axes.loglog([xMin, xMax], [scaleMinPos1, scaleMaxPos1], linestyle=':', color='k', label="_nolegend_", lw=1)
+    axes.loglog([xMin, xMax], [scaleMinPos2, scaleMaxPos2], linestyle=':', color='k', label="_nolegend_", lw=1)
+
+    iPlot = 0
+    for experiment in experiments:
+
+         xPos = []
+         yPos = []
+
+         r = 0
+         for resolution in resolutions:
+
+             filename = "./output_%s_%i_%s/output.2000.nc" %(experiment,resolution,runtype)
+             filenameParticlesTemplate = "./output_%s_%i_%s/particles_output*" %(experiment,resolution,runtype)
+
+             #norm = get_norm_area(filename, filenameParticlesTemplate)
+             norm = check_particle_positions_start_end(filenameParticlesTemplate)
+             xPos.append(resolutions[r])
+             yPos.append(norm)
+             r = r + 1
+
+         error = float('nan')
+         print(xPos, yPos)
+
+         axes.loglog(xPos, yPos, marker=markers[iPlot], dashes=dashes[iPlot], color="black", markersize=5.0)
+
+         iPlot = iPlot + 1
+
+
+    axes.legend(legendLabels, frameon=False, loc=4, fontsize=8, handlelength=4)
+
+    plt.minorticks_off()
+
+    axes.set_xlabel("Time resolution (sec)")
+    axes.set_ylabel(r"max error norm for position")
+    axes.set_xticks([450,900,1800,3600])
+    axes.set_xticklabels(["450","900","1800","3600"])
+    axes.tick_params(
+        axis='x',          # changes apply to the x-axis
+        which='minor',      # both major and minor ticks are affected
+        bottom='off',      # ticks along the bottom edge are off
+        top='off',         # ticks along the top edge are off
+        labelbottom='off')
+
+    plt.tight_layout(pad=0.2, w_pad=0.2, h_pad=0.2)
+    plt.savefig("advection_error_pos_convergence_%s.png" %(runtype),dpi=300)
+    plt.savefig("advection_error_pos_convergence_%s.eps" %(runtype))
+
+    #area
+    fig, axes = plt.subplots(1, 1, figsize=(8*cm,6.5*cm))
+
+    axes.loglog([xMin, xMax], [scaleMinArea1, scaleMaxArea1], linestyle=':', color='k', label="_nolegend_", lw=1)
+    axes.loglog([xMin, xMax], [scaleMinArea2, scaleMaxArea2], linestyle=':', color='k', label="_nolegend_", lw=1)
+
+    iPlot = 0
+    for experiment in experiments:
+
+         xArea = []
+         yArea = []
+
+         r = 0
+         for resolution in resolutions:
+
+             filename = "./output_%s_%i_%s/output.2000.nc" %(experiment,resolution,runtype)
+             filenameParticlesTemplate = "./output_%s_%i_%s/particles_output*" %(experiment,resolution,runtype)
+
+             norm = get_norm_area(filename, filenameParticlesTemplate)
+             xArea.append(resolutions[r])
+             yArea.append(norm)
+             r = r + 1
+
+         error = float('nan')
+         print(xArea, yArea)
+         error = yArea[-1]
+
+         axes.loglog(xArea, yArea, marker=markers[iPlot], dashes=dashes[iPlot], color="black", markersize=5.0)
+
+         iPlot = iPlot + 1
+
+
+    axes.legend(legendLabels, frameon=False, loc=4, fontsize=8, handlelength=4)
+
+    plt.minorticks_off()
+
+    axes.set_xlabel("Time resolution (sec)")
+    axes.set_ylabel(r"$L_2$ error norm for area")
+    axes.set_xticks([450,900,1800,3600])
+    axes.set_xticklabels(["450","900","1000","3600"])
+    axes.tick_params(
+        axis='x',          # changes apply to the x-axis
+        which='minor',      # both major and minor ticks are affected
+        bottom='off',      # ticks along the bottom edge are off
+        top='off',         # ticks along the top edge are off
+        labelbottom='off')
+
+    plt.tight_layout(pad=0.2, w_pad=0.2, h_pad=0.2)
+    plt.savefig("advection_error_convergence_%s.png" %(runtype),dpi=300)
+    plt.savefig("advection_error_convergence_%s.eps" %(runtype))
+
+    try:
+        import colorama
+        if (error < 1e-12):
+           message = "TEST PASSED: Absolute convergence error: %g" %(error)
+           print(colorama.Style.BRIGHT + colorama.Fore.GREEN + message + colorama.Style.RESET_ALL)
+        else:
+           message = "TEST FAILED: Absolute convergence error: %g" %(error)
+           print(colorama.Style.BRIGHT + colorama.Fore.MAGENTA + message + colorama.Style.RESET_ALL)
+    except ImportError:
+        print(message)
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Plot the advection error as a function of mesh size')
+
+    parser.add_argument('-t', required=True, dest='runtype', help='plot data for polympo or nonpolympo run')
+
+    args = parser.parse_args()
+
+    advection_error_convergence(args.runtype)

--- a/testcases/MPM/advection_time_convergence/advection_map.py
+++ b/testcases/MPM/advection_time_convergence/advection_map.py
@@ -1,0 +1,279 @@
+from netCDF4 import Dataset
+import numpy as np
+import matplotlib as mpl
+from matplotlib.patches import Polygon
+from matplotlib.collections import PatchCollection
+import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+import math, sys
+from scipy.interpolate import griddata
+from matplotlib.ticker import FormatStrFormatter
+import glob
+from average_particle_ice_area_to_cell import average_particle_ice_area_to_cell
+
+#---------------------------------------------------------------
+
+def get_mpas_patch_collection(nCells, nEdgesOnCell, verticesOnCell, xVertex, yVertex, zVertex, mpasArray, cmap):
+
+    patches = []
+    colours = []
+
+    minval =  1.0e30
+    maxval = -1.0e30
+
+    for iCell in range(0,nCells):
+
+        polygonVertices = []
+
+        lUse = True
+
+        for iVertexOnCell in range(0,nEdgesOnCell[iCell]):
+
+            iVertex = verticesOnCell[iCell,iVertexOnCell] - 1
+
+            polygonVertices.append((xVertex[iVertex],zVertex[iVertex]))
+
+            if (yVertex[iVertex] < 0.0):
+                lUse = False
+
+        if (lUse):
+
+            polygon = Polygon(polygonVertices)
+            patches.append(polygon)
+
+            colours.append(mpasArray[iCell])
+
+            minval = min(minval,mpasArray[iCell])
+            maxval = max(maxval,mpasArray[iCell])
+
+    patchCollection = PatchCollection(patches, cmap=cmap, rasterized=False)
+    patchCollection.set_array(np.array(colours))
+    patchCollection.set_linewidth(0)
+    patchCollection.set_clim(vmin=0.0,vmax=1.0)
+
+    return patchCollection, minval, maxval
+
+#---------------------------------------------------------------
+
+def plot_subfigure_patch(axes,
+                         nCells,
+                         nEdgesOnCell,
+                         verticesOnCell,
+                         xVertex,
+                         yVertex,
+                         zVertex,
+                         array,
+                         minX,
+                         maxX,
+                         minY,
+                         maxY,
+                         sciNote=False,
+                         diffPlot=False,
+                         title=None,
+                         cbTitle=None,
+                         subfigureLabel=None):
+
+    if (not diffPlot):
+        #colourMap = mpl.cm.jet
+        colourMap = mpl.cm.plasma
+    else:
+        colourMap = mpl.cm.RdBu
+
+    patchCollection, minArray, maxArray = get_mpas_patch_collection(nCells, nEdgesOnCell, verticesOnCell, xVertex, yVertex, zVertex, array, colourMap)
+    axes.add_collection(patchCollection)
+    axes.set_ylim([minY,maxY])
+    axes.set_xlim([minX,maxX])
+    axes.set_xticks([])
+    axes.set_yticks([])
+    axes.set_aspect('equal', adjustable='box')
+
+    if (title != None):
+        axes.set_title(title)
+
+    if (subfigureLabel != None):
+        axes.text(0.12, 0.9, subfigureLabel, verticalalignment='bottom', horizontalalignment='right',transform=axes.transAxes, fontsize=8)
+
+    divider = make_axes_locatable(axes)
+    cax = divider.append_axes("right", size="5%", pad=0.05)
+    cb = plt.colorbar(patchCollection,cax=cax)
+    #if (cbTitle != None):
+    #    cb.ax.set_ylabel(cbTitle)
+    if (sciNote):
+        cb.formatter.set_powerlimits((0, 0))
+        cb.update_ticks()
+    if (diffPlot):
+        cmLimit = max(math.fabs(minArray),math.fabs(maxArray))
+        cb.set_clim(-cmLimit,cmLimit)
+
+#---------------------------------------------------------------
+
+def plot_subfigure_contour(axes,
+                           nCells,
+                           xCell,
+                           yCell,
+                           zCell,
+                           array,
+                           minX,
+                           maxX,
+                           minY,
+                           maxY,
+                           sciNote=False,
+                           diffPlot=False,
+                           title=None,
+                           cbTitle=None,
+                           subfigureLabel=None,
+                           contourLevels=None,
+                           addCLabels=False):
+
+    axes.set_ylim([minY,maxY])
+    axes.set_xlim([minX,maxX])
+    axes.set_xticks([])
+    axes.set_yticks([])
+    axes.set_aspect('equal', adjustable='box')
+
+    if (title != None):
+        axes.set_title(title)
+
+    if (subfigureLabel != None):
+        #axes.text(0.12, 0.9, subfigureLabel, verticalalignment='bottom', horizontalalignment='right',transform=axes.transAxes, fontsize=8)
+        axes.set_title(subfigureLabel, loc='left')
+
+    # contour plot
+    x = []
+    y = []
+    z = []
+    for iCell in range(0,nCells):
+
+        if (yCell[iCell] > 0.0):
+
+            x.append(xCell[iCell])
+            y.append(zCell[iCell])
+            z.append(array[iCell])
+
+    xi = np.linspace(minX, maxX, 100)
+    yi = np.linspace(minY, maxY, 100)
+    X, Y = np.meshgrid(xi,yi)
+
+    print("  Griddata...")
+    zi = griddata((x,y), z, (X,Y), method='linear', fill_value=0)
+
+    print("  Contour plot...")
+    contourPlot = axes.contour(X, Y, zi, 10, linewidths=0.5, colors='k', levels=contourLevels)
+    if (addCLabels):
+        axes.clabel(contourPlot, inline=1, fontsize=5, inline_spacing=1, fmt=FormatStrFormatter('%g'))#, manual=clabelLocations, inline_spacing=1)
+
+#---------------------------------------------------------------
+
+def advection_map(runtype):
+
+    iTime = -1
+
+    #res = "2562"
+    #res = "10242"
+    #res = "40962"
+    #res = "163842"
+
+    res = 3600
+
+    experiment1 = "cosine_bell"
+    experiment2 = "slotted_cylinder"
+
+    print("Load data...")
+
+    # mesh
+    filename = "./output_%s_%i_%s/output.2000.nc" %(experiment2,res,runtype)
+
+    file = Dataset(filename, "r")
+
+    nCells = len(file.dimensions["nCells"])
+
+    #sphereRadius = file.attributes["sphere_radius"]
+    sphereRadius = 6371229.0
+
+    nEdgesOnCell   = file.variables["nEdgesOnCell"][:]
+    verticesOnCell = file.variables["verticesOnCell"][:]
+    xVertex        = file.variables["xVertex"][:]
+    yVertex        = file.variables["yVertex"][:]
+    zVertex        = file.variables["zVertex"][:]
+    xCell          = file.variables["xCell"][:]
+    yCell          = file.variables["yCell"][:]
+    zCell          = file.variables["zCell"][:]
+
+    file.close()
+
+    # slotted cylinder
+    filenamesParticleSC = sorted(glob.glob("./output_%s_%i_%s/particles_output*" %(experiment2,res,runtype)))
+
+    iceAreaInitialSC = average_particle_ice_area_to_cell(filenamesParticleSC[ 0], nCells)
+    iceAreaSC        = average_particle_ice_area_to_cell(filenamesParticleSC[-1], nCells)
+
+    # cosine bell
+    filenamesParticleCB = sorted(glob.glob("./output_%s_%i_%s/particles_output*" %(experiment1,res,runtype)))
+
+    iceAreaInitialCB = average_particle_ice_area_to_cell(filenamesParticleCB[ 0], nCells)
+    iceAreaCB        = average_particle_ice_area_to_cell(filenamesParticleCB[-1], nCells)
+
+    scaleFactor = 0.9
+    #scaleFactor = 1.0
+
+    minX = -sphereRadius * scaleFactor
+    maxX =  sphereRadius * scaleFactor
+
+    minY = -sphereRadius * scaleFactor
+    maxY =  sphereRadius * scaleFactor
+
+    # plotting
+
+    cm = 1/2.54  # centimeters in inches
+    plt.rcParams["font.family"] = "Times New Roman"
+    #mpl.rc('text', usetex=True)
+    SMALL_SIZE = 8
+    MEDIUM_SIZE = 8
+    BIGGER_SIZE = 8
+    plt.rc('font', size=SMALL_SIZE)          # controls default text sizes
+    plt.rc('axes', titlesize=SMALL_SIZE)     # fontsize of the axes title
+    plt.rc('axes', labelsize=MEDIUM_SIZE)    # fontsize of the x and y labels
+    plt.rc('xtick', labelsize=SMALL_SIZE)    # fontsize of the tick labels
+    plt.rc('ytick', labelsize=SMALL_SIZE)    # fontsize of the tick labels
+    plt.rc('legend', fontsize=SMALL_SIZE)    # legend fontsize
+    plt.rc('figure', titlesize=BIGGER_SIZE)  # fontsize of the figure title
+
+    #mpl.rcParams['axes.linewidth'] = 0.5
+
+
+    print("Create plots...")
+
+    fig, axes = plt.subplots(2, 2, figsize=(15*cm,11*cm))
+
+    contour = True
+
+    if (contour):
+
+        plot_subfigure_contour(axes[0,0], nCells, xCell, yCell, zCell, iceAreaInitialCB, minX, maxX, minY, maxY, False, False, r'', 'm',
+                               '(a) CB initial condition', contourLevels=[0.05,0.1,0.3,0.5,0.7,0.9,0.95])
+        plot_subfigure_contour(axes[1,0], nCells, xCell, yCell, zCell, iceAreaInitialSC, minX, maxX, minY, maxY, False, False, r'', 'm',
+                               '(c) SC initial condition', contourLevels=[0.05,0.1,0.3,0.5,0.7,0.9,0.95])
+        plot_subfigure_contour(axes[0,1], nCells, xCell, yCell, zCell, iceAreaCB,      minX, maxX, minY, maxY, False, False, r'', 'm',
+                               '(b) CB final', contourLevels=[0.05,0.1,0.3,0.5,0.7,0.9,0.95])
+        plot_subfigure_contour(axes[1,1], nCells, xCell, yCell, zCell, iceAreaSC,      minX, maxX, minY, maxY, False, False, r'', 'm',
+                               '(d) SC final ', contourLevels=[0.05,0.1,0.3,0.5,0.7,0.9,0.95])
+
+        #plt.tight_layout()
+        plt.tight_layout(pad=0.2, w_pad=0.2, h_pad=0.2)
+        plt.savefig("advection_map_%s.png" %(runtype),dpi=300)
+        plt.savefig("advection_map_%s.eps" %(runtype))
+
+    else:
+
+        plot_subfigure_patch(axes[0,0], nCells, nEdgesOnCell, verticesOnCell, xVertex, yVertex, zVertex, iceAreaInitialCB, minX, maxX, minY, maxY, False, False, r'', 'm', '(a)')
+        plot_subfigure_patch(axes[1,0], nCells, nEdgesOnCell, verticesOnCell, xVertex, yVertex, zVertex, iceAreaInitialSC, minX, maxX, minY, maxY, False, False, r'', 'm', '(c)')
+        plot_subfigure_patch(axes[0,1], nCells, nEdgesOnCell, verticesOnCell, xVertex, yVertex, zVertex, iceAreaCB,      minX, maxX, minY, maxY, False, False, r'', 'm', '(b)')
+        plot_subfigure_patch(axes[1,1], nCells, nEdgesOnCell, verticesOnCell, xVertex, yVertex, zVertex, iceAreaSC,      minX, maxX, minY, maxY, False, False, r'', 'm', '(d)')
+
+        plt.savefig("advection_map.png",bbox_inches="tight",dpi=400)
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    advection_map()

--- a/testcases/MPM/advection_time_convergence/average_particle_ice_area_to_cell.py
+++ b/testcases/MPM/advection_time_convergence/average_particle_ice_area_to_cell.py
@@ -1,0 +1,52 @@
+from netCDF4 import Dataset
+import numpy as np
+import numpy.ma as ma
+from numba import njit
+
+#---------------------------------------------------------
+
+@njit
+def average(nCells,
+            nParticles,
+            statusMP,
+            iCellMP,
+            iceAreaCellMP):
+
+    iceAreaCell = np.zeros(nCells)
+    nParticlesCell = np.zeros(nCells)
+
+    for iParticle in range(0,nParticles):
+        if (statusMP[iParticle] == 1):
+            iCell = iCellMP[iParticle]
+            iceAreaCell[iCell] += iceAreaCellMP[iParticle]
+            nParticlesCell[iCell] += 1.0
+
+    for iCell in range(0,nCells):
+        if (nParticlesCell[iCell] > 0.0):
+            iceAreaCell[iCell] /= nParticlesCell[iCell]
+
+    return iceAreaCell
+
+#---------------------------------------------------------
+
+def average_particle_ice_area_to_cell(filenameParticles, nCells):
+
+    filein = Dataset(filenameParticles,"r")
+
+    nParticles = len(filein.dimensions["nParticles"])
+
+    statusMP      = ma.getdata(filein.variables["statusMP"][0,:])
+    iCellMP       = ma.getdata(filein.variables["iCellMP"][0,:])-1
+    iceAreaCellMP = ma.getdata(filein.variables["iceAreaCellMP"][0,:])
+
+    filein.close()
+
+    iceAreaCell = average(nCells,
+                          nParticles,
+                          statusMP,
+                          iCellMP,
+                          iceAreaCellMP)
+
+    return iceAreaCell
+
+#---------------------------------------------------------

--- a/testcases/MPM/advection_time_convergence/check_particle_positions_start_end.py
+++ b/testcases/MPM/advection_time_convergence/check_particle_positions_start_end.py
@@ -1,0 +1,86 @@
+from netCDF4 import Dataset
+import sys
+import math
+import glob
+import argparse
+
+#-------------------------------------------------------------------------------
+
+def check_particle_positions_start_end(filenameTemplate):
+
+    try:
+        import colorama
+        colorama.init()
+    except ImportError:
+        pass
+
+    print()
+    message = "Check particles start-end positions for %s" %(filenameTemplate)
+    print(message)
+    print("-"*len(message))
+
+    filenames = sorted(glob.glob(filenameTemplate))
+
+    filein = Dataset(filenames[0],"r")
+
+    nParticles1 = len(filein.dimensions["nParticles"])
+
+    statusMP1 = filein.variables["statusMP"][0,:]
+    cellIDCreationMP1 = filein.variables["cellIDCreationMP"][0,:]
+    creationIndexMP1 = filein.variables["creationIndexMP"][0,:]
+    posnMP1 = filein.variables["posnMP"][0,:,:]
+
+    filein.close()
+
+
+    filein = Dataset(filenames[-1],"r")
+
+    nParticles2 = len(filein.dimensions["nParticles"])
+
+    statusMP2 = filein.variables["statusMP"][0,:]
+    cellIDCreationMP2 = filein.variables["cellIDCreationMP"][0,:]
+    creationIndexMP2 = filein.variables["creationIndexMP"][0,:]
+    posnMP2 = filein.variables["posnMP"][0,:,:]
+
+    filein.close()
+
+    if (nParticles1 != nParticles2):
+         raise Exception("nParticles not consistent for " + filenameIn)
+
+
+    particleIDToIndex = {}
+    for iParticle2 in range(0, nParticles2):
+         if (statusMP2[iParticle2] == 1):
+                particleIDToIndex[(cellIDCreationMP2[iParticle2],creationIndexMP2[iParticle2])] = iParticle2
+
+
+    maxDistance = -sys.float_info.max
+    for iParticle1 in range(0,nParticles1):
+         if (statusMP1[iParticle1] == 1):
+                iParticle2 = particleIDToIndex[(cellIDCreationMP1[iParticle1],creationIndexMP1[iParticle1])]
+                distance = math.sqrt(math.pow(posnMP2[iParticle2,0]-posnMP1[iParticle1,0],2) +
+                                     math.pow(posnMP2[iParticle2,1]-posnMP1[iParticle1,1],2) +
+                                     math.pow(posnMP2[iParticle2,2]-posnMP1[iParticle1,2],2))
+                maxDistance = max(maxDistance,distance)
+
+    message = "Final max distance: %g" %(maxDistance)
+    try:
+        import colorama
+        print(colorama.Style.BRIGHT + colorama.Fore.MAGENTA + message + colorama.Style.RESET_ALL)
+    except ImportError:
+        print(message)
+    print()
+
+    return maxDistance
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Determine error in particle positions after one rotation on sphere')
+
+    parser.add_argument('-f', required=True, dest='filenameTemplate', help='filename template for particle files')
+
+    args = parser.parse_args()
+
+    check_particle_positions_start_end(args.filenameTemplate)

--- a/testcases/MPM/advection_time_convergence/create_particles.py
+++ b/testcases/MPM/advection_time_convergence/create_particles.py
@@ -1,0 +1,42 @@
+import sys
+
+sys.path.append("../../../utils/MPM/particle_initialization/")
+from initial_particle_positions import initial_particle_positions
+
+import os
+
+#--------------------------------------------------------------------
+
+def create_particles():
+
+    reses = ["2562","10242","40962","163842"]
+
+    icTypes = ["cosine_bell","slotted_cylinder"]
+
+    for icType in icTypes:
+
+        print("icType: ", icType)
+
+        for res in reses:
+
+            print("  Res: ", res)
+
+            filenameOut = "particles_%s_%s.nc" %(icType,res)
+
+            if (not os.path.isfile(filenameOut)):
+
+                filenameMesh = "grid.%s.nc" %(res)
+
+                initial_particle_positions(filenameMesh,
+                                           filenameOut,
+                                           "number",
+                                           9,
+                                           "onePerEdge",
+                                           icType,
+                                           6371229.0)
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    create_particles()

--- a/testcases/MPM/advection_time_convergence/namelist.seaice.advection
+++ b/testcases/MPM/advection_time_convergence/namelist.seaice.advection
@@ -1,0 +1,548 @@
+&seaice_model
+    config_dt = 3600.0
+    config_calendar_type = 'noleap'
+    config_start_time = '2000-01-01_00:00:00'
+    config_stop_time = 'none'
+    config_run_duration = '10_00:00:00'
+    config_num_halos = 2
+/
+&io
+    config_pio_num_iotasks = 0
+    config_pio_stride = 1
+    config_write_output_on_startup = true
+    config_test_case_diag = false
+    config_test_case_diag_type = 'none'
+    config_full_abort_write = true
+/
+&decomposition
+    config_block_decomp_file_prefix = 'graphs/graph.info.part.'
+    config_number_of_blocks = 0
+    config_explicit_proc_decomp = false
+    config_proc_decomp_file_prefix = 'graphs/graph.info.part.'
+    config_use_halo_exch = true
+    config_aggregate_halo_exch = false
+    config_reuse_halo_exch = false
+    config_load_balance_timers = false
+/
+&restart
+    config_do_restart = false
+    config_restart_timestamp_name = 'restart_timestamp'
+    config_do_restart_hbrine = false
+    config_do_restart_zsalinity = false
+    config_do_restart_bgc = false
+    config_do_restart_snow_density = false
+    config_do_restart_snow_grain_radius = false
+/
+&dimensions
+    config_nCategories = 1
+    config_nFloeCategories = 1
+    config_nIceLayers = 7
+    config_nSnowLayers = 1
+/
+&initialize
+    config_earth_radius = 6371229.0
+    config_initial_condition_type = 'none'
+    config_initial_ice_area = 1.0
+    config_initial_ice_volume = 1.0
+    config_initial_snow_volume = 0.0
+    config_initial_latitude_north = 70.0
+    config_initial_latitude_south = -60.0
+    config_initial_velocity_type = 'none'
+    config_initial_uvelocity = 0.0
+    config_initial_vvelocity = 0.0
+    config_calculate_coriolis = true
+/
+&use_sections
+    config_use_dynamics = true
+    config_use_velocity_solver = false
+    config_use_advection = true
+    config_use_mpm = true
+    config_use_forcing = false
+    config_use_column_physics = false
+    config_use_prescribed_ice = false
+    config_use_prescribed_ice_forcing = false
+/
+&forcing
+    config_atmospheric_forcing_type = 'CORE'
+    config_forcing_start_time = '2000-01-01_00:00:00'
+    config_forcing_cycle_start = '2000-01-01_00:00:00'
+    config_forcing_cycle_duration = '2-00-00_00:00:00'
+    config_forcing_precipitation_units = 'mm_per_sec'
+    config_forcing_sst_type = 'ncar'
+    config_forcing_bgc_type = 'ISPOL'
+    config_update_ocean_fluxes = false
+    config_frazil_coupling_type = 'external'
+    config_include_pond_freshwater_feedback = false
+/
+&testing
+    config_use_test_ice_shelf = false
+    config_testing_system_test = false
+    config_use_congelation_basal_melt = true
+    config_use_lateral_melt = true
+    config_use_latent_processes = true
+    config_limit_air_temperatures = true
+/
+&velocity_solver
+    config_dynamics_subcycle_number = 1
+    config_rotate_cartesian_grid = false
+    config_include_metric_terms = true
+    config_elastic_subcycle_number = 120
+    config_strain_scheme = 'variational'
+    config_constitutive_relation_type = 'evp'
+    config_stress_divergence_scheme = 'variational'
+    config_variational_basis = 'wachspress'
+    config_variational_denominator_type = 'original'
+    config_wachspress_integration_type = 'dunavant'
+    config_wachspress_integration_order = 8
+    config_calc_velocity_masks = true
+    config_average_variational_strain = false
+    config_use_air_stress = true
+    config_use_ocean_stress = true
+    config_use_surface_tilt = true
+    config_geostrophic_surface_tilt = true
+    config_ocean_stress_type = 'quadratic'
+    config_use_special_boundaries_velocity = false
+    config_use_special_boundaries_velocity_masks = false
+/
+&advection
+    config_advection_type = 'none'
+    config_monotonic = true
+    config_conservation_check = false
+    config_monotonicity_check = false
+    config_recover_tracer_means_check = false
+/
+&mpm
+    config_use_mpm_transport = true
+    config_use_mpm_velocity_solver = true
+    config_use_mpm_polympo = false
+    config_mpm_create_particles = false
+    config_mpm_particle_init_type = 'number'
+    config_mpm_particle_posn_init_type = 'even'
+    config_mpm_particle_init_number = 9
+    config_mpm_particle_block_size = 128
+    config_mpm_assembly_test = false
+    config_mpm_polympo_init_test = false
+/
+&column_package
+    config_column_physics_type = 'icepack'
+    config_column_element_type = 'cells'
+    config_use_column_shortwave = true
+    config_use_column_vertical_thermodynamics = true
+    config_use_column_biogeochemistry = false
+    config_use_column_itd_thermodynamics = true
+    config_use_column_ridging = true
+    config_use_column_snow_tracers = false
+/
+&column_tracers
+    config_use_ice_age = true
+    config_use_first_year_ice = true
+    config_use_level_ice = true
+    config_use_cesm_meltponds = false
+    config_use_level_meltponds = true
+    config_use_topo_meltponds = false
+    config_use_aerosols = false
+    config_use_effective_snow_density = false
+    config_use_snow_grain_radius = false
+    config_use_special_boundaries_tracers = false
+    config_use_floe_size_distribution = false
+/
+&biogeochemistry
+    config_use_brine = false
+    config_use_vertical_zsalinity = false
+    config_use_vertical_biochemistry = false
+    config_use_shortwave_bioabsorption = false
+    config_use_vertical_tracers = false
+    config_use_skeletal_biochemistry = false
+    config_use_nitrate = false
+    config_use_carbon = false
+    config_use_chlorophyll = false
+    config_use_ammonium = false
+    config_use_silicate = false
+    config_use_DMS = false
+    config_use_nonreactive = false
+    config_use_humics = false
+    config_use_DON = false
+    config_use_iron = false
+    config_use_macromolecules = false
+    config_use_modal_aerosols = false
+    config_use_zaerosols = false
+    config_skeletal_bgc_flux_type = 'Jin2006'
+    config_scale_initial_vertical_bgc = false
+    config_biogrid_bottom_molecular_sublayer = 0.006
+    config_biogrid_top_molecular_sublayer = 0.006
+    config_bio_gravity_drainage_length_scale = 0.024
+    config_zsalinity_molecular_sublayer = 0.0
+    config_zsalinity_gravity_drainage_scale = 0.028
+    config_snow_porosity_at_ice_surface = -0.3
+    config_new_ice_fraction_biotracer = 0.80
+    config_fraction_biotracer_in_frazil = 0.80
+    config_ratio_Si_to_N_diatoms = 1.80
+    config_ratio_Si_to_N_small_plankton = 0.00
+    config_ratio_Si_to_N_phaeocystis = 0.00
+    config_ratio_S_to_N_diatoms = 0.03
+    config_ratio_S_to_N_small_plankton = 0.03
+    config_ratio_S_to_N_phaeocystis = 0.03
+    config_ratio_Fe_to_C_diatoms = 0.0033
+    config_ratio_Fe_to_C_small_plankton = 0.0033
+    config_ratio_Fe_to_C_phaeocystis = 0.1
+    config_ratio_Fe_to_N_diatoms = 0.023
+    config_ratio_Fe_to_N_small_plankton = 0.023
+    config_ratio_Fe_to_N_phaeocystis = 0.7
+    config_ratio_Fe_to_DON = 0.023
+    config_ratio_Fe_to_DOC_saccharids = 0.1
+    config_ratio_Fe_to_DOC_lipids = 0.033
+    config_respiration_fraction_of_growth = 0.05
+    config_rapid_mobile_to_stationary_time = 5200.0
+    config_long_mobile_to_stationary_time = 173000.0
+    config_algal_maximum_velocity = 0.0000000111
+    config_ratio_Fe_to_dust = 0.035
+    config_solubility_of_Fe_in_dust = 0.005
+    config_chla_absorptivity_of_diatoms = 0.03
+    config_chla_absorptivity_of_small_plankton = 0.01
+    config_chla_absorptivity_of_phaeocystis = 0.05
+    config_light_attenuation_diatoms = 0.8
+    config_light_attenuation_small_plankton = 0.67
+    config_light_attenuation_phaeocystis = 0.67
+    config_light_inhibition_diatoms = 0.018
+    config_light_inhibition_small_plankton = 0.0025
+    config_light_inhibition_phaeocystis = 0.01
+    config_maximum_growth_rate_diatoms = 1.44
+    config_maximum_growth_rate_small_plankton = 0.851
+    config_maximum_growth_rate_phaeocystis = 0.851
+    config_temperature_growth_diatoms = 0.06
+    config_temperature_growth_small_plankton = 0.06
+    config_temperature_growth_phaeocystis = 0.06
+    config_grazed_fraction_diatoms = 0.0
+    config_grazed_fraction_small_plankton = 0.1
+    config_grazed_fraction_phaeocystis = 0.1
+    config_mortality_diatoms = 0.007
+    config_mortality_small_plankton = 0.007
+    config_mortality_phaeocystis = 0.007
+    config_temperature_mortality_diatoms = 0.03
+    config_temperature_mortality_small_plankton = 0.03
+    config_temperature_mortality_phaeocystis = 0.03
+    config_exudation_diatoms = 0.0
+    config_exudation_small_plankton = 0.0
+    config_exudation_phaeocystis = 0.0
+    config_nitrate_saturation_diatoms = 1.0
+    config_nitrate_saturation_small_plankton = 1.0
+    config_nitrate_saturation_phaeocystis = 1.0
+    config_ammonium_saturation_diatoms = 0.3
+    config_ammonium_saturation_small_plankton = 0.3
+    config_ammonium_saturation_phaeocystis = 0.3
+    config_silicate_saturation_diatoms = 4.0
+    config_silicate_saturation_small_plankton = 0.0
+    config_silicate_saturation_phaeocystis = 0.0
+    config_iron_saturation_diatoms = 1.0
+    config_iron_saturation_small_plankton = 0.2
+    config_iron_saturation_phaeocystis = 0.1
+    config_fraction_spilled_to_DON = 0.6
+    config_degredation_of_DON = 0.03
+    config_fraction_DON_ammonium = 0.25
+    config_fraction_loss_to_saccharids = 0.4
+    config_fraction_loss_to_lipids = 0.4
+    config_fraction_exudation_to_saccharids = 1.0
+    config_fraction_exudation_to_lipids = 1.0
+    config_remineralization_saccharids = 0.03
+    config_remineralization_lipids = 0.03
+    config_maximum_brine_temperature = 0.0
+    config_salinity_dependence_of_growth = 1.0
+    config_minimum_optical_depth = 0.1
+    config_slopped_grazing_fraction = 0.5
+    config_excreted_fraction = 0.5
+    config_fraction_mortality_to_ammonium = 0.5
+    config_fraction_iron_remineralized = 0.3
+    config_nitrification_rate = 0.0
+    config_desorption_loss_particulate_iron = 3065.0
+    config_maximum_loss_fraction = 0.9
+    config_maximum_ratio_iron_to_saccharids = 0.2
+    config_respiration_loss_to_DMSPd = 0.75
+    config_DMSP_to_DMS_conversion_fraction = 0.5
+    config_DMSP_to_DMS_conversion_time = 3.0
+    config_DMS_oxidation_time = 10.0
+    config_mobility_type_diatoms = 0.0
+    config_mobility_type_small_plankton = 0.5
+    config_mobility_type_phaeocystis = 0.5
+    config_mobility_type_nitrate = -1.0
+    config_mobility_type_ammonium = 1.0
+    config_mobility_type_silicate = -1.0
+    config_mobility_type_DMSPp = 0.5
+    config_mobility_type_DMSPd = -1.0
+    config_mobility_type_humics = 1.0
+    config_mobility_type_saccharids = 0.5
+    config_mobility_type_lipids = 0.5
+    config_mobility_type_inorganic_carbon = -1.0
+    config_mobility_type_proteins = 0.5
+    config_mobility_type_dissolved_iron = 0.5
+    config_mobility_type_particulate_iron = 0.5
+    config_mobility_type_black_carbon1 = 1.0
+    config_mobility_type_black_carbon2 = 1.0
+    config_mobility_type_dust1 = 1.0
+    config_mobility_type_dust2 = 1.0
+    config_mobility_type_dust3 = 1.0
+    config_mobility_type_dust4 = 1.0
+    config_ratio_C_to_N_diatoms = 7.0
+    config_ratio_C_to_N_small_plankton = 7.0
+    config_ratio_C_to_N_phaeocystis = 7.0
+    config_ratio_chla_to_N_diatoms = 2.1
+    config_ratio_chla_to_N_small_plankton = 1.1
+    config_ratio_chla_to_N_phaeocystis = 0.84
+    config_scales_absorption_diatoms = 2.0
+    config_scales_absorption_small_plankton = 4.0
+    config_scales_absorption_phaeocystis = 5.0
+    config_ratio_C_to_N_proteins = 7.0
+/
+&shortwave
+    config_shortwave_type = 'dEdd'
+    config_albedo_type = 'ccsm3'
+    config_use_snicar_ad = false
+    config_visible_ice_albedo = 0.78
+    config_infrared_ice_albedo = 0.36
+    config_visible_snow_albedo = 0.98
+    config_infrared_snow_albedo = 0.70
+    config_variable_albedo_thickness_limit = 0.3
+    config_ice_shortwave_tuning_parameter = 0.0
+    config_pond_shortwave_tuning_parameter = 0.0
+    config_snow_shortwave_tuning_parameter = 1.5
+    config_temp_change_snow_grain_radius_change = 1.5
+    config_max_melting_snow_grain_radius = 1500.0
+    config_algae_absorption_coefficient = 0.6
+    config_use_shortwave_redistribution = false
+    config_shortwave_redistribution_fraction = 0.9
+    config_shortwave_redistribution_threshold = 0.02
+/
+&snow
+    config_snow_redistribution_scheme = 'none'
+    config_fallen_snow_radius = 54.526
+    config_use_snow_liquid_ponds = false
+    config_new_snow_density = 100.0
+    config_max_snow_density = 450.0
+    config_minimum_wind_compaction = 10.0
+    config_wind_compaction_factor = 27.3
+    config_snow_redistribution_factor = 0.3
+    config_max_dry_snow_radius = 1800.0
+    config_snow_thermal_conductivity = 0.3
+/
+&meltponds
+    config_snow_to_ice_transition_depth = 0.0
+    config_pond_refreezing_type = 'hlid'
+    config_pond_flushing_factor = 1.0e-3
+    config_min_meltwater_retained_fraction = 0.15
+    config_max_meltwater_retained_fraction = 1.0
+    config_pond_depth_to_fraction_ratio = 0.8
+    config_snow_on_pond_ice_tapering_parameter = 0.03
+    config_critical_pond_ice_thickness = 0.01
+/
+&thermodynamics
+    config_thermodynamics_type = 'mushy'
+    config_heat_conductivity_type = 'bubbly'
+    config_rapid_mode_channel_radius = 0.5e-3
+    config_rapid_model_critical_Ra = 10.0
+    config_rapid_mode_aspect_ratio = 1.0
+    config_slow_mode_drainage_strength = -5.0e-8
+    config_slow_mode_critical_porosity = 0.05
+    config_macro_drainage_timescale = 10.
+    config_congelation_ice_porosity = 0.85
+/
+&itd
+    config_itd_conversion_type = 'linear remap'
+    config_category_bounds_type = 'original'
+/
+&floesize
+    config_floeshape = 0.66
+    config_floediam = 300.0
+/
+&ridging
+    config_ice_strength_formulation = 'Rothrock75'
+    config_ridging_participation_function = 'exponential'
+    config_ridging_redistribution_function = 'exponential'
+    config_ridging_efolding_scale = 3.0
+    config_ratio_ridging_work_to_PE = 17.0
+/
+&atmosphere
+    config_atmos_boundary_method = 'similarity'
+    config_calc_surface_stresses = true
+    config_calc_surface_temperature = true
+    config_use_form_drag = false
+    config_use_high_frequency_coupling = false
+    config_boundary_layer_iteration_number = 5
+/
+&ocean
+    config_use_ocean_mixed_layer = true
+    config_ocean_mixed_layer_type = 'cice'
+    config_min_friction_velocity = 0.0005
+    config_ocean_heat_transfer_type = 'constant'
+    config_sea_freezing_temperature_type = 'mushy'
+    config_ocean_surface_type = 'free'
+    config_use_data_icebergs = false
+    config_salt_flux_coupling_type = 'constant'
+    config_ice_ocean_drag_coefficient = 0.00536
+/
+&diagnostics
+    config_check_state = false
+/
+&AM_highFrequencyOutput
+    config_AM_highFrequencyOutput_enable = false
+    config_AM_highFrequencyOutput_compute_interval = 'output_interval'
+    config_AM_highFrequencyOutput_output_stream = 'highFrequencyOutput'
+    config_AM_highFrequencyOutput_compute_on_startup = true
+    config_AM_highFrequencyOutput_write_on_startup = true
+/
+&AM_temperatures
+    config_AM_temperatures_enable = false
+    config_AM_temperatures_compute_interval = 'dt'
+    config_AM_temperatures_output_stream = 'none'
+    config_AM_temperatures_compute_on_startup = false
+    config_AM_temperatures_write_on_startup = false
+/
+&AM_regionalStatistics
+    config_AM_regionalStatistics_enable = false
+    config_AM_regionalStatistics_compute_interval = 'output_interval'
+    config_AM_regionalStatistics_output_stream = 'regionalStatisticsOutput'
+    config_AM_regionalStatistics_compute_on_startup = false
+    config_AM_regionalStatistics_write_on_startup = false
+    config_AM_regionalStatistics_ice_extent_limit = 0.15
+/
+&AM_ridgingDiagnostics
+    config_AM_ridgingDiagnostics_enable = false
+    config_AM_ridgingDiagnostics_compute_interval = 'dt'
+    config_AM_ridgingDiagnostics_output_stream = 'none'
+    config_AM_ridgingDiagnostics_compute_on_startup = false
+    config_AM_ridgingDiagnostics_write_on_startup = false
+/
+&AM_conservationCheck
+    config_AM_conservationCheck_enable = false
+    config_AM_conservationCheck_compute_interval = 'dt'
+    config_AM_conservationCheck_output_stream = 'conservationCheckOutput'
+    config_AM_conservationCheck_compute_on_startup = false
+    config_AM_conservationCheck_write_on_startup = false
+    config_AM_conservationCheck_write_to_logfile = true
+/
+&AM_geographicalVectors
+    config_AM_geographicalVectors_enable = false
+    config_AM_geographicalVectors_compute_interval = 'dt'
+    config_AM_geographicalVectors_output_stream = 'none'
+    config_AM_geographicalVectors_compute_on_startup = false
+    config_AM_geographicalVectors_write_on_startup = false
+/
+&AM_loadBalance
+    config_AM_loadBalance_enable = false
+    config_AM_loadBalance_compute_interval = 'output_interval'
+    config_AM_loadBalance_output_stream = 'loadBalanceOutput'
+    config_AM_loadBalance_compute_on_startup = false
+    config_AM_loadBalance_write_on_startup = false
+    config_AM_loadBalance_nProcs = 32
+/
+&AM_maximumIcePresence
+    config_AM_maximumIcePresence_enable = false
+    config_AM_maximumIcePresence_compute_interval = 'dt'
+    config_AM_maximumIcePresence_output_stream = 'maximumIcePresenceOutput'
+    config_AM_maximumIcePresence_compute_on_startup = false
+    config_AM_maximumIcePresence_write_on_startup = false
+    config_AM_maximumIcePresence_start_time = '0000-00-00_00:00:00'
+/
+&AM_miscellaneous
+    config_AM_miscellaneous_enable = false
+    config_AM_miscellaneous_compute_interval = 'dt'
+    config_AM_miscellaneous_output_stream = 'none'
+    config_AM_miscellaneous_compute_on_startup = false
+    config_AM_miscellaneous_write_on_startup = false
+/
+&AM_areaVariables
+    config_AM_areaVariables_enable = false
+    config_AM_areaVariables_compute_interval = 'dt'
+    config_AM_areaVariables_output_stream = 'none'
+    config_AM_areaVariables_compute_on_startup = false
+    config_AM_areaVariables_write_on_startup = false
+/
+&AM_pondDiagnostics
+    config_AM_pondDiagnostics_enable = false
+    config_AM_pondDiagnostics_compute_interval = 'dt'
+    config_AM_pondDiagnostics_output_stream = 'none'
+    config_AM_pondDiagnostics_compute_on_startup = false
+    config_AM_pondDiagnostics_write_on_startup = false
+/
+&AM_unitConversion
+    config_AM_unitConversion_enable = false
+    config_AM_unitConversion_compute_interval = 'dt'
+    config_AM_unitConversion_output_stream = 'none'
+    config_AM_unitConversion_compute_on_startup = false
+    config_AM_unitConversion_write_on_startup = false
+/
+&AM_pointwiseStats
+    config_AM_pointwiseStats_enable = false
+    config_AM_pointwiseStats_compute_interval = 'dt'
+    config_AM_pointwiseStats_output_stream = 'pointwiseStatsOutput'
+    config_AM_pointwiseStats_compute_on_startup = false
+    config_AM_pointwiseStats_write_on_startup = false
+/
+&AM_iceShelves
+    config_AM_iceShelves_enable = false
+    config_AM_iceShelves_compute_interval = 'output_interval'
+    config_AM_iceShelves_output_stream = 'iceShelvesOutput'
+    config_AM_iceShelves_compute_on_startup = true
+    config_AM_iceShelves_write_on_startup = true
+/
+&AM_icePresent
+    config_AM_icePresent_enable = false
+    config_AM_icePresent_compute_interval = 'dt'
+    config_AM_icePresent_output_stream = 'none'
+    config_AM_icePresent_compute_on_startup = false
+    config_AM_icePresent_write_on_startup = false
+/
+&AM_timeSeriesStatsDaily
+    config_AM_timeSeriesStatsDaily_enable = false
+    config_AM_timeSeriesStatsDaily_compute_on_startup = false
+    config_AM_timeSeriesStatsDaily_write_on_startup = false
+    config_AM_timeSeriesStatsDaily_compute_interval = 'dt'
+    config_AM_timeSeriesStatsDaily_output_stream = 'timeSeriesStatsDailyOutput'
+    config_AM_timeSeriesStatsDaily_restart_stream = 'timeSeriesStatsDailyRestart'
+    config_AM_timeSeriesStatsDaily_operation = 'avg'
+    config_AM_timeSeriesStatsDaily_reference_times = 'initial_time'
+    config_AM_timeSeriesStatsDaily_duration_intervals = 'repeat_interval'
+    config_AM_timeSeriesStatsDaily_repeat_intervals = 'reset_interval'
+    config_AM_timeSeriesStatsDaily_reset_intervals = '00-00-01_00:00:00'
+    config_AM_timeSeriesStatsDaily_backward_output_offset = '00-00-01_00:00:00'
+/
+&AM_timeSeriesStatsMonthly
+    config_AM_timeSeriesStatsMonthly_enable = false
+    config_AM_timeSeriesStatsMonthly_compute_on_startup = false
+    config_AM_timeSeriesStatsMonthly_write_on_startup = false
+    config_AM_timeSeriesStatsMonthly_compute_interval = 'dt'
+    config_AM_timeSeriesStatsMonthly_output_stream = 'timeSeriesStatsMonthlyOutput'
+    config_AM_timeSeriesStatsMonthly_restart_stream = 'timeSeriesStatsMonthlyRestart'
+    config_AM_timeSeriesStatsMonthly_operation = 'avg'
+    config_AM_timeSeriesStatsMonthly_reference_times = 'initial_time'
+    config_AM_timeSeriesStatsMonthly_duration_intervals = 'repeat_interval'
+    config_AM_timeSeriesStatsMonthly_repeat_intervals = 'reset_interval'
+    config_AM_timeSeriesStatsMonthly_reset_intervals = '00-01-00_00:00:00'
+    config_AM_timeSeriesStatsMonthly_backward_output_offset = '00-01-00_00:00:00'
+/
+&AM_timeSeriesStatsClimatology
+    config_AM_timeSeriesStatsClimatology_enable = false
+    config_AM_timeSeriesStatsClimatology_compute_on_startup = false
+    config_AM_timeSeriesStatsClimatology_write_on_startup = false
+    config_AM_timeSeriesStatsClimatology_compute_interval = '00-00-00_01:00:00'
+    config_AM_timeSeriesStatsClimatology_output_stream = 'timeSeriesStatsClimatologyOutput'
+    config_AM_timeSeriesStatsClimatology_restart_stream = 'timeSeriesStatsClimatologyRestart'
+    config_AM_timeSeriesStatsClimatology_operation = 'avg'
+    config_AM_timeSeriesStatsClimatology_reference_times = '00-03-01_00:00:00;00-06-01_00:00:00;00-09-01_00:00:00;00-12-01_00:00:00'
+    config_AM_timeSeriesStatsClimatology_duration_intervals = '00-03-00_00:00:00;00-03-00_00:00:00;00-03-00_00:00:00;00-03-00_00:00:00'
+    config_AM_timeSeriesStatsClimatology_repeat_intervals = '01-00-00_00:00:00;01-00-00_00:00:00;01-00-00_00:00:00;01-00-00_00:00:00'
+    config_AM_timeSeriesStatsClimatology_reset_intervals = '1000-00-00_00:00:00;1000-00-00_00:00:00;1000-00-00_00:00:00;1000-00-00_00:00:00'
+    config_AM_timeSeriesStatsClimatology_backward_output_offset = '00-03-00_00:00:00'
+/
+&AM_timeSeriesStatsCustom
+    config_AM_timeSeriesStatsCustom_enable = false
+    config_AM_timeSeriesStatsCustom_compute_on_startup = false
+    config_AM_timeSeriesStatsCustom_write_on_startup = false
+    config_AM_timeSeriesStatsCustom_compute_interval = '00-00-00_01:00:00'
+    config_AM_timeSeriesStatsCustom_output_stream = 'timeSeriesStatsCustomOutput'
+    config_AM_timeSeriesStatsCustom_restart_stream = 'timeSeriesStatsCustomRestart'
+    config_AM_timeSeriesStatsCustom_operation = 'avg'
+    config_AM_timeSeriesStatsCustom_reference_times = 'initial_time'
+    config_AM_timeSeriesStatsCustom_duration_intervals = 'repeat_interval'
+    config_AM_timeSeriesStatsCustom_repeat_intervals = 'reset_interval'
+    config_AM_timeSeriesStatsCustom_reset_intervals = '00-00-07_00:00:00'
+    config_AM_timeSeriesStatsCustom_backward_output_offset = '00-00-01_00:00:00'
+/

--- a/testcases/MPM/advection_time_convergence/namelist.seaice.advection
+++ b/testcases/MPM/advection_time_convergence/namelist.seaice.advection
@@ -105,15 +105,15 @@
     config_use_special_boundaries_velocity_masks = false
 /
 &advection
-    config_advection_type = 'none'
+    config_advection_type = 'mpm'
     config_monotonic = true
     config_conservation_check = false
     config_monotonicity_check = false
     config_recover_tracer_means_check = false
 /
 &mpm
-    config_use_mpm_transport = true
     config_use_mpm_velocity_solver = true
+    config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false
     config_mpm_create_particles = false
     config_mpm_particle_init_type = 'number'

--- a/testcases/MPM/advection_time_convergence/plot_testcase.py
+++ b/testcases/MPM/advection_time_convergence/plot_testcase.py
@@ -1,0 +1,172 @@
+from netCDF4 import Dataset
+import matplotlib
+import matplotlib.pyplot as plt
+from matplotlib.patches import Polygon
+from matplotlib.collections import PatchCollection
+import matplotlib.cm as cm
+import numpy as np
+import os
+from average_particle_ice_area_to_cell import average_particle_ice_area_to_cell
+import glob
+
+#-------------------------------------------------------------
+
+def plot_subfigure(axis, array, nCells, nEdgesOnCell, verticesOnCell, xCell, yCell, zCell, xVertex, yVertex, zVertex, cmin, cmax, cmap):
+
+    xMin =  1.0e30
+    xMax = -1.0e30
+    yMin =  1.0e30
+    yMax = -1.0e30
+
+    cmap = plt.get_cmap(cmap)
+
+    patches = []
+    colors = []
+
+    for iCell in range(0,nCells):
+
+        if (yCell[iCell] > 0.0):
+
+            vertices = []
+            for iVertexOnCell in range(0,nEdgesOnCell[iCell]):
+                iVertex = verticesOnCell[iCell,iVertexOnCell]
+                vertices.append((xVertex[iVertex],zVertex[iVertex]))
+
+            colors.append(array[iCell])
+
+            patches.append(Polygon(vertices))
+
+            xMin = min(xMin,xVertex[iVertex])
+            xMax = max(xMax,xVertex[iVertex])
+
+            yMin = min(yMin,zVertex[iVertex])
+            yMax = max(yMax,zVertex[iVertex])
+
+    pc = PatchCollection(patches, cmap=cmap)
+    pc.set_array(np.array(colors))
+    pc.set_clim(cmin, cmax)
+
+    axis.add_collection(pc)
+
+    axis.set_xlim(xMin,xMax)
+    axis.set_ylim(yMin,yMax)
+    axis.set_aspect("equal")
+
+    axis.ticklabel_format(style='plain')
+    axis.tick_params(axis='x', \
+                     which='both', \
+                     bottom=False, \
+                     top=False, \
+                     labelbottom=False)
+    axis.tick_params(axis='y', \
+                     which='both', \
+                     left=False, \
+                     right=False, \
+                     labelleft=False)
+
+#-------------------------------------------------------------
+
+def plot_testcase(runtype):
+
+    #nGrids = [2562,10242,40962,163842]
+    nGrids = [2562]
+    tsteps = [3600, 1800, 900, 450]
+    testTypes = ["cosine_bell","slotted_cylinder"]
+    iTimes = [0,-1]
+
+    for tstep in tsteps:
+
+        print("tstep: ", tstep)
+        filesExist = False
+        for testType in testTypes:
+            filenamein = "./output_%s_%i_%s/output.2000.nc" %(testType,tstep,runtype)
+            if (os.path.exists(filenamein)):
+                filesExist = True
+
+        if (filesExist):
+
+            fig, axes = plt.subplots(2,4)
+
+            iTestType = -1
+            for testType in testTypes:
+                iTestType += 1
+
+                print("  Test type: ", testType)
+
+                # mesh
+                filenamein = "./output_%s_%i_%s/output.2000.nc" %(testType,tstep,runtype)
+
+                filein = Dataset(filenamein,"r")
+
+                nCells = len(filein.dimensions["nCells"])
+
+                nEdgesOnCell = filein.variables["nEdgesOnCell"][:]
+                verticesOnCell = filein.variables["verticesOnCell"][:]
+                xCell = filein.variables["xCell"][:]
+                yCell = filein.variables["yCell"][:]
+                zCell = filein.variables["zCell"][:]
+                xVertex = filein.variables["xVertex"][:]
+                yVertex = filein.variables["yVertex"][:]
+                zVertex = filein.variables["zVertex"][:]
+                verticesOnCell[:] = verticesOnCell[:] - 1
+
+                filein.close()
+
+                # iceArea
+                filenameParticlesTemplate = "./output_%s_%i_%s/particles_output*" %(testType,tstep,runtype)
+                filenames = sorted(glob.glob(filenameParticlesTemplate))
+
+                iceAreaCell0 = average_particle_ice_area_to_cell(filenames[0], nCells)
+
+                iMethod = -1
+                for iTime in iTimes:
+                    iMethod +=1
+
+                    print("iTime: ", iTime)
+
+                    iceAreaCell = average_particle_ice_area_to_cell(filenames[iTime], nCells)
+
+                    plot_subfigure(axes[iMethod,iTestType*2],
+                                   iceAreaCell,
+                                   nCells,
+                                   nEdgesOnCell,
+                                   verticesOnCell,
+                                   xCell,
+                                   yCell,
+                                   zCell,
+                                   xVertex,
+                                   yVertex,
+                                   zVertex,
+                                   0.0,
+                                   1.0,
+                                   "viridis")
+
+                    iceAreaCellDiff = iceAreaCell - iceAreaCell0
+
+                    if (iMethod != 0):
+                        plot_subfigure(axes[iMethod,iTestType*2+1],
+                                       iceAreaCellDiff,
+                                       nCells,
+                                       nEdgesOnCell,
+                                       verticesOnCell,
+                                       xCell,
+                                       yCell,
+                                       zCell,
+                                       xVertex,
+                                       yVertex,
+                                       zVertex,
+                                       -1.0,
+                                       1.0,
+                                       "bwr")
+                    else:
+                        axes[iMethod, iTestType*2+1].axis('off')
+
+            plt.savefig("advection_%6.6i.%s.png" %(tstep,runtype),dpi=300)
+            plt.cla()
+            plt.close(fig)
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    plot_testcase("")

--- a/testcases/MPM/advection_time_convergence/plot_transport.py
+++ b/testcases/MPM/advection_time_convergence/plot_transport.py
@@ -1,0 +1,88 @@
+from netCDF4 import Dataset
+import matplotlib.pyplot as plt
+import math
+from mpl_toolkits import mplot3d
+import numpy as np
+from mpl_toolkits.mplot3d.art3d import Line3DCollection
+import glob
+import argparse
+
+#-------------------------------------------------------------------------------
+
+def plot_file(filenameIn, filenameOut):
+
+    iTime = 0
+
+    filein = Dataset(filenameIn,"r")
+
+    sphere_radius = filein.sphere_radius
+
+    nParticles = len(filein.dimensions["nParticles"])
+
+    posnMP = filein.variables["posnMP"][:]
+
+    procIDParticle = filein.variables["procIDParticle"][:]
+
+    indexToCellIDParticle = filein.variables["indexToCellIDParticle"][:]
+
+    nValid = 0
+    valid = []
+    colors = []
+    for iParticle in range(0,nParticles):
+        mag = math.sqrt(math.pow(posnMP[iTime,iParticle,0],2) + \
+                        math.pow(posnMP[iTime,iParticle,1],2) + \
+                        math.pow(posnMP[iTime,iParticle,2],2))
+        if (mag > 1e-8):
+            nValid += 1
+            valid.append(True)
+            colors.append(procIDParticle[iTime,iParticle])
+        else:
+            valid.append(False)
+
+
+
+    filein.close()
+
+    fig, axis = plt.subplots(subplot_kw={'projection':'3d'})
+
+    axis.scatter(posnMP[iTime,valid,0],posnMP[iTime,valid,1],posnMP[iTime,valid,2],c=colors)
+
+    axis.set_xlim((-1.1*sphere_radius,1.1*sphere_radius))
+    axis.set_ylim((-1.1*sphere_radius,1.1*sphere_radius))
+    axis.set_zlim((-1.1*sphere_radius,1.1*sphere_radius))
+
+    axis.set_xlabel("x")
+    axis.set_ylabel("y")
+    axis.set_zlabel("z")
+
+    plt.savefig(filenameOut)
+    plt.cla()
+    plt.close(fig)
+
+
+    return nValid
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Plot the MPM advection test case')
+
+    parser.add_argument('-f', required=True, dest='filenameTemplate', help='filename template for particle files')
+
+    args = parser.parse_args()
+
+    nskip = 1
+
+    filenames = sorted(glob.glob(args.filenameTemplate))
+
+    iFile = 0
+    for filenameIn in filenames[::nskip]:
+        print(filenameIn)
+
+        filenameOut = "./plots/plot_transport_%4.4i.png" %(iFile)
+
+        nValid = plot_file(filenameIn, filenameOut)
+
+        print(filenameOut, nValid)
+        iFile += 1

--- a/testcases/MPM/advection_time_convergence/run_model.py
+++ b/testcases/MPM/advection_time_convergence/run_model.py
@@ -1,0 +1,78 @@
+import sys
+
+sys.path.append("../../../utils/testcases")
+from execute_model import execute_model
+
+import os
+import argparse
+
+#-------------------------------------------------------------------------------
+
+def run_model(nCells,
+              nProcs,
+              runtype,
+              logFile):
+
+    print()
+    message = "Run model for nCells: %s and nProcs: %i" %(nCells, nProcs)
+    print(message)
+    print("-"*len(message))
+
+    MPAS_SEAICE_EXECUTABLE = os.environ.get('MPAS_SEAICE_EXECUTABLE')
+    if (MPAS_SEAICE_EXECUTABLE is None):
+        MPAS_SEAICE_EXECUTABLE = "../../../../MPAS-Seaice-MPM/components/mpas-seaice/seaice_model"
+        print("Using executable in standard location: %s" %(MPAS_SEAICE_EXECUTABLE))
+
+    icTypes = ["cosine_bell","slotted_cylinder"]
+    #icTypes = ["cosine_bell"]
+
+    tsteps = [3600, 1800, 900, 450]
+
+    for icType in icTypes:
+
+        for tstep in tsteps:
+
+            print()
+            message = "IC type: %s, gridSize: %s, Time Step: %i" %(icType, nCells, tstep)
+            print(message)
+            print("-"*len(message))
+
+            if (not os.path.isdir("output")):
+                os.mkdir("output")
+
+            os.system("rm grid.nc ic.nc particles.nc namelist.seaice")
+            os.system("ln -s namelist.seaice.%s.%i namelist.seaice" %(runtype, tstep))
+            os.system("ln -s grid.%s.nc grid.nc" %(nCells))
+            os.system("ln -s ic_%s_%i.nc ic.nc" %(icType, tstep))
+            os.system("ln -s particles_%s_%s.nc particles.nc" %(icType, nCells))
+
+            os.system("rm -rf output_%s_%i_%s" %(icType, tstep, runtype))
+
+
+            if (nProcs > 1):
+                os.chdir("./graphs")
+
+                cmd = "ln -s graph.%s.info.part.%i graph.info.part.%i" %(nCells, nProcs, nProcs)
+                print(cmd)
+                os.system(cmd)
+
+                os.chdir("..")
+
+            execute_model(MPAS_SEAICE_EXECUTABLE,
+                          nProcs,
+                          logFile)
+
+            os.system("mv output output_%s_%i_%s" %(icType, tstep, runtype))
+            os.system("mv log.seaice.0000.out log.seaice.0000.out_%s_%i_%s" %(icType, tstep, runtype))
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', dest="nCells", type=char, required=True)
+    parser.add_argument('-p', dest="nProcs", type=int, required=True)
+    parser.add_argument('-r', dest="runtype", type=char, required=False)
+    args = parser.parse_args()
+
+    run_model(args.nCells, args.nProcs, args.runtype)

--- a/testcases/MPM/advection_time_convergence/run_testcase.py
+++ b/testcases/MPM/advection_time_convergence/run_testcase.py
@@ -1,0 +1,148 @@
+import os, sys, math, f90nml, argparse
+
+from run_model import run_model
+from plot_testcase import plot_testcase
+from advection_map import advection_map
+from advection_equatorial import advection_equatorial
+from advection_error_convergence import advection_error_convergence
+from create_particles import create_particles
+
+sys.path.append("../../advection")
+from create_ics import create_ic_file
+
+sys.path.append("../advection")
+from add_deldyn_to_ics import add_deldyn_to_ics
+from check_particles_moved import check_particles_moved
+
+sys.path.append("../../../testing")
+from testing_utils import create_new_namelist
+
+sys.path.append("../../../utils/testcases")
+from get_testcase_data_spherical import get_testcase_data_spherical
+
+#-------------------------------------------------------------------------------
+
+def run_testcase(logFilename=None):
+
+    if (logFilename is not None):
+        logFile = open(logFilename,"a")
+        logFile.write("\nAdvection test case\n")
+        logFile.write(  "===================\n")
+        logFile.flush()
+    else:
+        logFile = None
+
+    particleFilename1 = "/particles_output.2000-01-01_00.00.00.nc"
+    particleFilename2 = "/particles_output.2000-01-06_00.00.00.nc"
+
+    outDirs = [
+        "output_cosine_bell_3600",
+        "output_cosine_bell_1800",
+        "output_cosine_bell_900",
+        "output_cosine_bell_450",
+        "output_slotted_cylinder_3600",
+        "output_slotted_cylinder_1800",
+        "output_slotted_cylinder_900",
+        "output_slotted_cylinder_450"]
+
+    res = "2562"
+    icTypes = ["cosine_bell", "slotted_cylinder"]
+    DynamicsTimeStep = [3600, 1800, 900, 450]
+    usePolympos = [False, True]
+
+    print("Get testcase data")
+    print("=================")
+    get_testcase_data_spherical()
+
+    print("\nCreate ICs")
+    print("==========")
+    create_ic_file(res, "slotted_cylinder" , math.pi / 6.0)
+    create_ic_file(res, "cosine_bell"      , math.pi / 6.0)
+
+    print("\nAdd deldyn to IC")
+    print("==========")
+    for icType in icTypes:
+       cmd = "cp ic_%s_%s.nc ic_%s.nc" %(icType,res,icType)
+       os.system(cmd)
+    for tstep in DynamicsTimeStep:
+       add_deldyn_to_ics(tstep,res)
+       for icType in icTypes:
+            cmd = "cp ic_%s_%s.nc ic_%s_%i.nc" %(icType,res,icType,tstep)
+            os.system(cmd)
+            cmd = "cp ic_%s.nc ic_%s_%s.nc" %(icType,icType,res)
+            os.system(cmd)
+
+    print("\nCreate particles")
+    print("================")
+    create_particles()
+
+    print("\nCreate namelists")
+    print("================")
+
+    for usePolympo in usePolympos:
+
+        print("usePolympo: ", usePolympo)
+        if (usePolympo):
+             usePolympoStr = "polympo"
+        else:
+             usePolympoStr = "nonpolympo"
+
+        t = 0
+        for tstep in DynamicsTimeStep:
+
+            nmlChanges = {"mpm":{"config_use_mpm_polympo":usePolympo},
+                          "seaice_model":{"config_dt":DynamicsTimeStep[t]}}
+
+            new_namelist = "namelist.seaice.%s.%i" %(usePolympoStr, tstep)
+            create_new_namelist("namelist.seaice.advection", new_namelist, nmlChanges)
+
+            t = t + 1
+
+        print("\nRun models")
+        print("==========")
+        run_model(res,
+                  1,
+                  usePolympoStr,
+                  logFile)
+
+        print("\nCheck particles moved")
+        print("=====================")
+        for outDir in outDirs:
+            check_particles_moved(outDir+"_"+usePolympoStr+particleFilename1,
+                                  outDir+"_"+usePolympoStr+particleFilename2)
+
+        print("\nPlot test case")
+        print("==============")
+        if (usePolympo):
+            runtype = "polympo"
+        else:
+            runtype = "nonpolympo"
+        plot_testcase(runtype)
+
+        print("\nAdvection map")
+        print("=============")
+        advection_map(runtype)
+
+        print("\nAdvection equatorial")
+        print("====================")
+        advection_equatorial(runtype)
+
+        print("\nAdvection error convergence")
+        print("===========================")
+        advection_error_convergence(runtype)
+
+    if (logFile is not None):
+        logFile.close()
+
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-l', dest='logFilename')
+
+    args = parser.parse_args()
+
+    run_testcase(args.logFilename)

--- a/testcases/MPM/advection_time_convergence/streams.seaice
+++ b/testcases/MPM/advection_time_convergence/streams.seaice
@@ -1,0 +1,372 @@
+<streams>
+<immutable_stream name="mesh"
+                  type="none"
+                  filename_template="mesh_variables.nc" />
+
+<immutable_stream name="input"
+                  type="input"
+                  filename_template="grid.nc"
+                  filename_interval="none"
+                  input_interval="initial_only" />
+
+<immutable_stream name="particleInput"
+                  type="input"
+                  filename_template="particles.nc"
+                  filename_interval="none"
+                  input_interval="initial_only" />
+
+<stream name="initialConditions"
+        type="input"
+        filename_template="ic.nc"
+        filename_interval="none"
+        input_interval="initial_only">
+
+        <var name="uVelocity"/>
+        <var name="vVelocity"/>
+	<var name="iceAreaCell"/>
+	<var name="iceVolumeCell"/>
+	<var name="iceAreaCategory"/>
+	<var name="iceVolumeCategory"/>
+        <var name="deluDyn"/>
+</stream>
+
+<immutable_stream name="restart"
+                  type="input;output"
+                  filename_template="restarts/restart.$Y-$M-$D_$h.$m.$s.nc"
+                  filename_interval="00_00:00:01"
+		  clobber_mode="replace_files"
+                  input_interval="initial_only"
+                  output_interval="00-03-00_00:00:00" />
+
+<stream name="output"
+        type="output"
+        filename_template="output/output.$Y.nc"
+        filename_interval="01-00-00_00:00:00"
+        clobber_mode="replace_files"
+        output_interval="00-00-00_04:00:00" >
+
+	<var name="xtime"/>
+	<var name="daysSinceStartOfSim"/>
+	<stream name="mesh"/>
+	<var name="iceAreaCell"/>
+	<var name="iceVolumeCell"/>
+	<var name="snowVolumeCell"/>
+	<var name="iceAreaCategory"/>
+	<var name="iceVolumeCategory"/>
+	<var name="snowVolumeCategory"/>
+	<var name="uVelocity"/>
+	<var name="vVelocity"/>
+        <var name="procID"/>
+</stream>
+
+<stream name="particlesOut"
+        type="output"
+        filename_template="output/particles_output.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="00-00-00_00:00:01"
+        clobber_mode="replace_files"
+        output_interval="00-00-00_04:00:00" >
+
+	<var name="statusMP"/>
+	<var name="iCellMP"/>
+        <var name="cellIDCreationMP"/>
+        <var name="creationIndexMP"/>
+        <var name="indexToCellIDMP"/>
+        <var name="procIDParticle"/>
+        <var name="posnMP"/>
+        <var name="iceAreaCellMP"/>
+        <var name="deluDyn"/>
+</stream>
+
+<immutable_stream name="LYqSixHourlyForcing"
+                  type="input"
+                  filename_template="forcing/atmosphere_forcing_six_hourly.$Y.nc"
+                  filename_interval="0001-00-00_00:00:00"
+		  reference_time="2000-01-01_03:00:00"
+                  input_interval="none" />
+
+<immutable_stream name="LYqMonthlyForcing"
+                  type="input"
+                  filename_template="forcing/atmosphere_forcing_monthly.nc"
+                  filename_interval="none"
+                  input_interval="none" />
+
+<immutable_stream name="NCARMonthlySSTForcing"
+                  type="input"
+                  filename_template="forcing/ocean_forcing_monthly.nc"
+                  filename_interval="none"
+                  input_interval="none" />
+
+<immutable_stream name="NCARMonthlyForcing"
+                  type="input"
+                  filename_template="forcing/ocean_forcing_monthly.nc"
+                  filename_interval="none"
+                  input_interval="none" />
+
+<stream name="dataIcebergForcing"
+                  type="input"
+                  filename_template="forcing/data_icebergs.nc"
+                  filename_interval="none"
+                  input_interval="none" >
+    <var name="bergFreshwaterFluxData"/>
+    <var name="xtime" />
+</stream>
+
+<stream name="abort_block"
+        type="output"
+        filename_template="abort_seaice_$Y-$M-$D_$h.$m.$s_block_$B.nc"
+        filename_interval="none"
+        clobber_mode="truncate"
+        output_interval="none" >
+
+	<stream name="mesh"/>
+	<stream name="abort_contents"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="xtime"/>
+</stream>
+
+<stream name="abort"
+        type="output"
+        filename_template="abort_seaice_$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="none"
+        clobber_mode="truncate"
+        output_interval="none" >
+
+	<stream name="mesh"/>
+	<stream name="abort_contents"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="xtime"/>
+</stream>
+
+<stream name="regionalStatisticsOutput"
+        type="output"
+        filename_template="analysis_members/regionalStatistics.nc"
+        filename_interval="none"
+        clobber_mode="replace_files"
+        packages="regionalStatisticsAMPKG"
+        output_interval="00-00-00_01:00:00" >
+
+	<var name="xtime"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="totalIceArea"/>
+	<var name="totalIceExtent"/>
+	<var name="totalIceVolume"/>
+	<var name="totalSnowVolume"/>
+	<var name="totalKineticEnergy"/>
+	<var name="rmsIceSpeed"/>
+	<var name="averageAlbedo"/>
+	<var name="maximumIceVolume"/>
+	<var name="maximumIceVolumeLocked"/>
+	<var name="maximumIceVolumeNotLocked"/>
+	<var name="maximumIcePressure"/>
+	<var name="maximumIceSpeed"/>
+</stream>
+
+<stream name="conservationCheckOutput"
+        type="output"
+        filename_template="analysis_members/conservationCheck.nc"
+        filename_interval="none"
+        clobber_mode="replace_files"
+        packages="conservationCheckAMPKG"
+        output_interval="00-00-00_01:00:00" >
+
+	<var name="xtime"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="initialEnergy"/>
+	<var name="finalEnergy"/>
+	<var name="energyChange"/>
+	<var name="netEnergyFlux"/>
+	<var name="absoluteEnergyError"/>
+	<var name="relativeEnergyError"/>
+	<var name="initialMass"/>
+	<var name="finalMass"/>
+	<var name="massChange"/>
+	<var name="netMassFlux"/>
+	<var name="absoluteMassError"/>
+	<var name="relativeMassError"/>
+	<var name="initialSalt"/>
+	<var name="finalSalt"/>
+	<var name="saltChange"/>
+	<var name="netSaltFlux"/>
+	<var name="absoluteSaltError"/>
+	<var name="relativeSaltError"/>
+</stream>
+
+
+<stream name="loadBalanceOutput"
+        type="output"
+        filename_template="analysis_members/seaice_loadBalance.nc"
+        filename_interval="none"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="loadBalanceAMPKG"
+        output_interval="00-00-00_01:00:00" >
+
+	<var name="xtime"/>
+	<var name="nCellsProcWithSeaIce"/>
+	<var name="nCellsProc"/>
+</stream>
+
+<stream name="maximumIcePresenceOutput"
+        type="output"
+        filename_template="analysis_members/seaice_maximumIcePresence.$Y.nc"
+        filename_interval="01-00-00_00:00:00"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="maximumIcePresenceAMPKG"
+        output_interval="01-00-00_00:00:00" >
+
+	<stream name="mesh"/>
+	<var name="xtime"/>
+	<var name="maximumIcePresence"/>
+</stream>
+
+<stream name="timeSeriesStatsDailyRestart"
+        type="input;output"
+        filename_template="restarts/restart.AM.timeSeriesStatsDaily.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="output_interval"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsDailyAMPKG"
+        input_interval="initial_only"
+        output_interval="stream:restart:output_interval" >
+
+</stream>
+
+<stream name="timeSeriesStatsDailyOutput"
+        type="output"
+        filename_template="analysis_members/timeSeriesStatsDaily.$Y-$M.nc"
+        filename_interval="00-01-00_00:00:00"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsDailyAMPKG"
+        output_interval="00-00-01_00:00:00" >
+
+</stream>
+
+<stream name="timeSeriesStatsMonthlyRestart"
+        type="input;output"
+        filename_template="restarts/restart.AM.timeSeriesStatsMonthly.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="output_interval"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsMonthlyAMPKG"
+        input_interval="initial_only"
+        output_interval="stream:restart:output_interval" >
+
+</stream>
+
+<stream name="timeSeriesStatsMonthlyOutput"
+        type="output"
+        filename_template="analysis_members/timeSeriesStatsMonthly.$Y-$M.nc"
+        filename_interval="00-01-00_00:00:00"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsMonthlyAMPKG"
+        output_interval="00-01-00_00:00:00" >
+
+	<var name="daysSinceStartOfSim"/>
+	<var name="icePresent"/>
+	<var name="iceAreaCell"/>
+	<var name="iceVolumeCell"/>
+	<var name="snowVolumeCell"/>
+	<var name="iceAreaCategory"/>
+	<var name="iceVolumeCategory"/>
+	<var name="snowVolumeCategory"/>
+	<var name="surfaceTemperatureCell"/>
+	<var name="uVelocityGeo"/>
+	<var name="vVelocityGeo"/>
+	<var name="shortwaveDown"/>
+	<var name="longwaveDown"/>
+	<var name="seaSurfaceTemperature"/>
+	<var name="seaSurfaceSalinity"/>
+	<var name="uOceanVelocityVertexGeo"/>
+	<var name="vOceanVelocityVertexGeo"/>
+	<var name="freezingMeltingPotential"/>
+	<var name="shortwaveScalingFactor"/>
+	<var name="airTemperature"/>
+	<var name="congelation"/>
+	<var name="frazilFormation"/>
+	<var name="snowiceFormation"/>
+	<var name="snowMelt"/>
+	<var name="surfaceIceMelt"/>
+	<var name="basalIceMelt"/>
+	<var name="lateralIceMelt"/>
+	<var name="airStressVertexUGeo"/>
+	<var name="airStressVertexVGeo"/>
+	<var name="icePressure"/>
+	<var name="divergence"/>
+	<var name="shear"/>
+	<var name="principalStress1Var"/>
+	<var name="principalStress2Var"/>
+	<var name="iceVolumeTendencyThermodynamics"/>
+	<var name="iceVolumeTendencyTransport"/>
+	<var name="iceAreaTendencyThermodynamics"/>
+	<var name="iceAreaTendencyTransport"/>
+	<var name="iceAgeTendencyThermodynamics"/>
+	<var name="iceAgeTendencyTransport"/>
+	<var name="iceAgeCell"/>
+	<var name="firstYearIceAreaCell"/>
+	<var name="levelIceAreaCell"/>
+	<var name="levelIceVolumeCell"/>
+	<var name="ridgedIceAreaAverage"/>
+	<var name="ridgedIceVolumeAverage"/>
+	<var name="bulkSalinity"/>
+	<var name="broadbandAlbedo"/>
+	<var name="absorbedShortwaveFluxInitialArea"/>
+	<var name="latentHeatFluxInitialArea"/>
+	<var name="sensibleHeatFluxInitialArea"/>
+	<var name="longwaveUpInitialArea"/>
+	<var name="evaporativeWaterFluxInitialArea"/>
+	<var name="meltPondAreaFinalArea"/>
+	<var name="meltPondDepthFinalArea"/>
+	<var name="meltPondLidThicknessFinalArea"/>
+
+</stream>
+
+<stream name="timeSeriesStatsClimatologyOutput"
+        type="output"
+        filename_template="analysis_members/timeSeriesStatsClimatology.$Y.nc"
+        filename_interval="01-00-00_00:00:00"
+        reference_time="0000-03-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsClimatologyAMPKG"
+        output_interval="00-03-00_00:00:00" >
+
+</stream>
+
+<stream name="timeSeriesStatsClimatologyRestart"
+        type="input;output"
+        filename_template="restarts/restart.AM.timeSeriesStatsClimatology.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="output_interval"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsClimatologyAMPKG"
+        input_interval="initial_only"
+        output_interval="stream:restart:output_interval" >
+
+</stream>
+
+<stream name="timeSeriesStatsCustomOutput"
+        type="output"
+        filename_template="analysis_members/timeSeriesStatsCustom.$Y$M-$D.nc"
+        filename_interval="00-00-07_00:00:00"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsCustomAMPKG"
+        output_interval="00-00-01_00:00:00" >
+
+</stream>
+
+<stream name="timeSeriesStatsCustomRestart"
+        type="input;output"
+        filename_template="restarts/restart.AM.timeSeriesStatsCustom.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="output_interval"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsCustomAMPKG"
+        input_interval="initial_only"
+        output_interval="stream:restart:output_interval" >
+
+</stream>
+
+</streams>

--- a/testcases/MPM/spherical_operators/reconstruction/reconstruction_map.py
+++ b/testcases/MPM/spherical_operators/reconstruction/reconstruction_map.py
@@ -145,8 +145,8 @@ def reconstruction_map():
         raise Exception("Missing output file: %s" %(filenameMPM))
     fileMPM = Dataset(filenameMPM,"r")
 
-    uVelocityMPM = fileMPM.variables["uVelocity"][0,:]
-    vVelocityMPM = fileMPM.variables["vVelocity"][0,:]
+    uVelocityMPM = fileMPM.variables["uVelocityInitial"][0,:]
+    vVelocityMPM = fileMPM.variables["vVelocityInitial"][0,:]
 
     uVelocityDiff = (uVelocityMPM - uVelocityAnalytical)
     vVelocityDiff = (vVelocityMPM - vVelocityAnalytical)

--- a/testcases/MPM/spherical_operators/reconstruction/reconstruction_scaling.py
+++ b/testcases/MPM/spherical_operators/reconstruction/reconstruction_scaling.py
@@ -44,8 +44,8 @@ def get_norm(filenameIC, filename, latitudeLimit):
 
     areaTriangle = fileMPAS.variables["areaTriangle"][:]
 
-    uVelocity = fileMPAS.variables["uVelocity"][0,:]
-    vVelocity = fileMPAS.variables["vVelocity"][0,:]
+    uVelocity = fileMPAS.variables["uVelocityInitial"][0,:]
+    vVelocity = fileMPAS.variables["vVelocityInitial"][0,:]
 
     normU = L2_norm(uVelocity, uVelocityAnalytical, nVertices, latVertex, areaTriangle, latitudeLimit)
     normV = L2_norm(vVelocity, vVelocityAnalytical, nVertices, latVertex, areaTriangle, latitudeLimit)

--- a/testcases/MPM/spherical_operators/reconstruction/streams.seaice
+++ b/testcases/MPM/spherical_operators/reconstruction/streams.seaice
@@ -48,8 +48,8 @@
 	<var name="iceAreaCell"/>
 	<var name="iceVolumeCell"/>
 	<var name="snowVolumeCell"/>
-	<var name="uVelocity"/>
-	<var name="vVelocity"/>
+	<var name="uVelocityInitial"/>
+	<var name="vVelocityInitial"/>
 </stream>
 
 <stream name="particlesOut"

--- a/testcases/MPM/spherical_operators/strain/streams.seaice.strain
+++ b/testcases/MPM/spherical_operators/strain/streams.seaice.strain
@@ -67,8 +67,8 @@
 	<var name="cellVerticesAtVertex"/>
 	<var name="cellsOnVertex"/>
 	<var name="areaCell"/>
-	<var name="uVelocity"/>
-   <var name="vVelocity"/>
+	<var name="uVelocityInitial"/>
+   <var name="vVelocityInitial"/>
 	<var name="stress11var"/>
 	<var name="stress22var"/>
 	<var name="stress12var"/>

--- a/testcases/MPM/spherical_operators/strain/velocity_map.py
+++ b/testcases/MPM/spherical_operators/strain/velocity_map.py
@@ -139,8 +139,8 @@ def velocity_map():
     # mpm
     fileMPM = Dataset("./output_mpmvar_40962/output.2000.nc","r")
 
-    uVelocityMPM = fileMPM.variables["uVelocity"][0,:]
-    vVelocityMPM = fileMPM.variables["vVelocity"][0,:]
+    uVelocityMPM = fileMPM.variables["uVelocityInitial"][0,:]
+    vVelocityMPM = fileMPM.variables["vVelocityInitial"][0,:]
 
     uVelocityDiff = uVelocity - uVelocityMPM
     vVelocityDiff = vVelocity - vVelocityMPM

--- a/testcases/MPM/spherical_operators/strain/velocity_scaling.py
+++ b/testcases/MPM/spherical_operators/strain/velocity_scaling.py
@@ -46,8 +46,8 @@ def get_norm_vertex(filenameIC, filename, latitudeLimit):
     latVertex = fileMPAS.variables["latVertex"][:]
     areaTriangle = fileMPAS.variables["areaTriangle"][:]
 
-    uVelocity= fileMPAS.variables["uVelocity"][:]
-    vVelocity= fileMPAS.variables["vVelocity"][:]
+    uVelocity= fileMPAS.variables["uVelocityInitial"][:]
+    vVelocity= fileMPAS.variables["vVelocityInitial"][:]
 
     fileMPAS.close()
 

--- a/testcases/MPM/velocity_advection_test/add_uvVelMP_to_particles_file.py
+++ b/testcases/MPM/velocity_advection_test/add_uvVelMP_to_particles_file.py
@@ -1,0 +1,76 @@
+import argparse
+from netCDF4 import Dataset
+import math
+import os
+
+from create_ics import latlon_vector_rotation_forward, latlon_from_xyz
+
+#--------------------------------------------------------------------
+
+def add_uvVelMP_to_particles_file(earthRadius, rotateCartesianGrid):
+
+    reses = ["2562","10242","40962","163842"]
+
+    for res in reses:
+
+       print("  Res: ", res)
+
+       icFilename = "particles_%s.nc" %(res)
+
+       if (not os.path.isfile(icFilename)):
+           raise Exception("IC file missing: "+icFilename)
+
+       filein = Dataset(icFilename,"a")
+
+       try:
+           filein.createDimension("TWO",2)
+       except:
+           pass
+
+       try:
+          uvVelMP = filein.createVariable("uvVelMP","d",dimensions=["nParticles","TWO"])
+       except:
+          uvVelMP = filein.variables["uvVelMP"][:]
+
+       try:
+          latCellMP = filein.createVariable("latCellMP","d",dimensions=["nParticles"])
+       except:
+          latCellMP = filein.variables["latCellMP"][:]
+
+       try:
+          lonCellMP = filein.createVariable("lonCellMP","d",dimensions=["nParticles"])
+       except:
+          lonCellMP = filein.variables["lonCellMP"][:]
+
+       nParticles = len(filein.dimensions["nParticles"])
+       posnMP = filein.variables["posnMP"][:,:]
+
+       for iParticle in range(0, nParticles):
+
+            latCellMP[iParticle], lonCellMP[iParticle] = latlon_from_xyz(
+                                                           posnMP[iParticle, 0],
+                                                           posnMP[iParticle, 1],
+                                                           posnMP[iParticle, 2],
+                                                           earthRadius)
+
+            uvVelMP[iParticle, 0] = 40.0 * math.cos(latCellMP[iParticle])
+            uvVelMP[iParticle, 1] = 0.0
+
+            uvVelMP[iParticle, 0], uvVelMP[iParticle, 1] = latlon_vector_rotation_forward(
+                                                           uvVelMP[iParticle, 0],
+                                                           uvVelMP[iParticle, 1],
+                                                           latCellMP[iParticle],
+                                                           lonCellMP[iParticle],
+                                                           posnMP[iParticle, 0],
+                                                           posnMP[iParticle, 1],
+                                                           posnMP[iParticle, 2],
+                                                           earthRadius,
+                                                           rotateCartesianGrid)
+
+       filein.close()
+
+#--------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    add_uvVelMP_to_particles_file(earthRadius, rotateCartesianGrid)

--- a/testcases/MPM/velocity_advection_test/advection_error_convergence.py
+++ b/testcases/MPM/velocity_advection_test/advection_error_convergence.py
@@ -1,0 +1,275 @@
+import sys
+
+sys.path.append("../../../utils/testcases")
+from log_messages import log_message
+
+from parse_time_string import parse_time_string
+
+from netCDF4 import Dataset
+import math
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+import numpy as np
+import glob
+import argparse
+
+#--------------------------------------------------------
+
+def L2_norm(numerical, analytical, nPoints, areaCell):
+
+    norm  = 0.0
+    denom = 0.0
+
+    for iPoint in range(0,nPoints):
+
+        norm  += areaCell[iPoint] * math.pow(numerical[iPoint] - analytical[iPoint],2)
+
+        denom += areaCell[iPoint] * math.pow(analytical[iPoint],2)
+
+    norm = math.sqrt(norm / denom)
+
+    return norm
+
+#--------------------------------------------------------
+
+def get_norm_area(filenameMesh, filenameParticlesTemplate):
+
+    fileMPAS = Dataset(filenameMesh, "r")
+
+    nCells = len(fileMPAS.dimensions["nCells"])
+
+    areaCell = fileMPAS.variables["areaCell"][:]
+
+    fileMPAS.close()
+
+    filenamesParticle = sorted(glob.glob(filenameParticlesTemplate))
+
+    iceAreaCellInitial = average_particle_ice_area_to_cell(filenamesParticle[ 0], nCells)
+    iceAreaCellFinal   = average_particle_ice_area_to_cell(filenamesParticle[-1], nCells)
+
+    norm = L2_norm(iceAreaCellFinal, iceAreaCellInitial, nCells, areaCell)
+
+    return norm
+#-------------------------------------------------------------------------------
+
+def latlon_from_xyz(x, y, z, r):
+
+    # given xyz coordinates determine the latitude and longitude
+
+    lon = math.atan2(y, x)
+    lat = math.asin(z/r)
+
+    return lat, lon
+
+#--------------------------------------------------------
+
+def posn_error(filenameTemplate):
+
+    filenames = sorted(glob.glob(filenameTemplate))
+    filein = Dataset(filenames[0],"r")
+    nParticles = len(filein.dimensions["nParticles"])
+    posnMP0 = filein.variables["posnMP"][0,:,:]
+    filein.close()
+
+    filein = Dataset(filenames[-1],"r")
+    posnMP = filein.variables["posnMP"][0,:,:]
+    xtime = filein.variables["xtime"][:,:]
+    t = parse_time_string(xtime)
+
+    r = math.sqrt(math.pow(posnMP0[0,0],2) + math.pow(posnMP0[0,1],2) + math.pow(posnMP0[0,2],2))
+
+    normLat = 0
+    normLon = 0
+    for iParticle in range(0, nParticles):
+        lat0, lon0 = latlon_from_xyz(posnMP0[iParticle,0], posnMP0[iParticle,1], posnMP0[iParticle,2], r)
+        lat, lon = latlon_from_xyz(posnMP[iParticle,0], posnMP[iParticle,1], posnMP[iParticle,2], r)
+        normLat = normLat + math.pow((lat - lat0), 2)
+        normLon = normLon + math.pow((lon - (lon0 + t/r)), 2)
+
+    normLat = math.sqrt(normLat) / nParticles
+    normLon = math.sqrt(normLon) / nParticles
+    return normLat, normLon
+
+#--------------------------------------------------------
+
+def L2_norm_particle(numerical, analytical, nParticles):
+
+    norm  = 0.0
+
+    for iParticle in range(0, nParticles):
+
+            norm  = norm + math.pow(numerical[iParticle] - analytical[iParticle],2)
+
+    norm = math.sqrt(norm) / nParticles
+
+    return norm
+
+#--------------------------------------------------------
+
+def get_norm_particle(fileIC, filenameTemplate):
+
+    filein = Dataset(fileIC,"r")
+    nParticles = len(filein.dimensions["nParticles"])
+    uvVelMP0 = filein.variables["uvVelMP"][:,:]
+    filein.close()
+
+    filenames = sorted(glob.glob(filenameTemplate))
+    filein = Dataset(filenames[-1],"r")
+    uvVelMP = filein.variables["uvVelMP"][0,:,:]
+    filein.close()
+
+    normU = L2_norm_particle(uvVelMP[:,0], uvVelMP0[:,0], nParticles)
+    normV = L2_norm_particle(uvVelMP[:,1], uvVelMP0[:,1], nParticles)
+
+    return normU, normV
+
+#--------------------------------------------------------
+
+def get_resolution(filename):
+
+    fileMPAS = Dataset(filename, "r")
+
+    nCells = len(fileMPAS.dimensions["nCells"])
+    nEdges = len(fileMPAS.dimensions["nEdges"])
+
+    # mean distance between cells
+    dcEdge = fileMPAS.variables["dcEdge"][:]
+
+    resolution = 0.0
+    for iEdge in range(0,nEdges):
+        resolution = resolution + dcEdge[iEdge]
+
+    resolution = resolution / float(nEdges)
+
+    fileMPAS.close()
+
+    return resolution / 1000.0
+
+#--------------------------------------------------------
+
+def get_grid_size(filename):
+
+    fileMPAS = Dataset(filename, "r")
+
+    nCells = len(fileMPAS.dimensions["nCells"])
+
+    return nCells
+
+#--------------------------------------------------------
+
+def advection_error_convergence(runtype,
+                                logFile=None):
+
+    resolutions = [2562,10242,40962,163842]
+
+    experiments = ["cos_lat"]
+
+    legendLabels = ["lat", "lon", "uMP", "vMP"]
+
+    markers = ['o','o','^','^']
+    linestyles = ["-", "--", "-", "--"]
+    dashes=[(1,0),(5,2.5),(1,0),(5,2.5)]
+
+    xMin = 60
+    xMax = 120
+
+    yMin = 3e-2
+    yMax = 1
+
+    scalePos1 = 0.15e-3 / math.pow(xMax,1)
+    scaleMinPos1 = math.pow(xMin,1) * scalePos1
+    scaleMaxPos1 = math.pow(xMax,1) * scalePos1
+
+    scalePos2 = 0.15e-3 / math.pow(xMax,2)
+    scaleMinPos2 = math.pow(xMin,2) * scalePos2
+    scaleMaxPos2 = math.pow(xMax,2) * scalePos2
+
+    #plot
+    cm = 1/2.54  # centimeters in inches
+    plt.rcParams["font.family"] = "Times New Roman"
+    SMALL_SIZE = 8
+    MEDIUM_SIZE = 8
+    BIGGER_SIZE = 8
+    plt.rc('font', size=SMALL_SIZE)          # controls default text sizes
+    plt.rc('axes', titlesize=SMALL_SIZE)     # fontsize of the axes title
+    plt.rc('axes', labelsize=MEDIUM_SIZE)    # fontsize of the x and y labels
+    plt.rc('xtick', labelsize=SMALL_SIZE)    # fontsize of the tick labels
+    plt.rc('ytick', labelsize=SMALL_SIZE)    # fontsize of the tick labels
+    plt.rc('legend', fontsize=SMALL_SIZE)    # legend fontsize
+    plt.rc('figure', titlesize=BIGGER_SIZE)  # fontsize of the figure title
+
+    #positions, velocity
+
+    fig, axes = plt.subplots(1, 1, figsize=(8*cm,6.5*cm))
+
+    axes.loglog([xMin, xMax], [scaleMinPos1, scaleMaxPos1], linestyle=':', color='k', label="_nolegend_", lw=1)
+    axes.loglog([xMin, xMax], [scaleMinPos2, scaleMaxPos2], linestyle=':', color='k', label="_nolegend_", lw=1)
+
+    iPlot = 0
+    for experiment in experiments:
+
+         xPos = []
+         yPos1 = []
+         yPos2 = []
+         yPos3 = []
+         yPos4 = []
+
+         for resolution in resolutions:
+
+             fileIC = "particles_%i.nc" %(resolution)
+             filename = "./output_%s_%i_%s/output.2000.nc" %(experiment,resolution,runtype)
+             filenameParticlesTemplate = "./output_%s_%i_%s/particles_output*" %(experiment,resolution,runtype)
+
+             normLat, normLon = posn_error(filenameParticlesTemplate)
+             xPos.append(get_resolution(filename))
+             yPos1.append(normLat)
+             yPos2.append(normLon)
+             normU, normV = get_norm_particle(fileIC, filenameParticlesTemplate)
+             yPos3.append(normU)
+             yPos4.append(normV)
+
+         error = float('nan')
+         print("error in lat: ", xPos, yPos1)
+         print("error in lon: ", xPos, yPos2)
+         print("error in uVel: ", xPos, yPos3)
+         print("error in vVel: ", xPos, yPos4)
+
+         axes.loglog(xPos, yPos1, marker=markers[iPlot], dashes=dashes[iPlot], color="black", markersize=5.0)
+         iPlot = iPlot + 1
+         axes.loglog(xPos, yPos2, marker=markers[iPlot], dashes=dashes[iPlot], color="black", markersize=5.0)
+         iPlot = iPlot + 1
+         axes.loglog(xPos, yPos3, marker=markers[iPlot], dashes=dashes[iPlot], color="black", markersize=5.0)
+         iPlot = iPlot + 1
+         axes.loglog(xPos, yPos4, marker=markers[iPlot], dashes=dashes[iPlot], color="black", markersize=5.0)
+
+
+    axes.legend(legendLabels, frameon=False, loc=4, fontsize=8, handlelength=4)
+
+    plt.minorticks_off()
+
+    axes.set_xlabel("Grid resolution (km)")
+    axes.set_ylabel(r"L2 error norm")
+    axes.set_xticks([60,120,240,480])
+    axes.set_xticklabels(["60","120","240","480"])
+    axes.tick_params(
+        axis='x',          # changes apply to the x-axis
+        which='minor',      # both major and minor ticks are affected
+        bottom='off',      # ticks along the bottom edge are off
+        top='off',         # ticks along the top edge are off
+        labelbottom='off')
+
+    plt.tight_layout(pad=0.2, w_pad=0.2, h_pad=0.2)
+    plt.savefig("advection_error_pos_convergence_%s.png" %(runtype),dpi=300)
+    plt.savefig("advection_error_pos_convergence_%s.eps" %(runtype))
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Plot the advection error as a function of mesh size')
+
+    parser.add_argument('-t', required=True, dest='runtype', help='plot data for polympo or nonpolympo run')
+
+    args = parser.parse_args()
+
+    advection_error_convergence(args.runtype)

--- a/testcases/MPM/velocity_advection_test/check_particles_moved.py
+++ b/testcases/MPM/velocity_advection_test/check_particles_moved.py
@@ -1,0 +1,85 @@
+import sys
+
+sys.path.append("../../../utils/testcases")
+from log_messages import log_message
+
+from netCDF4 import Dataset
+import numpy as np
+import argparse
+
+#------------------------------------------------------------------
+
+def set_globalID(creationIndexMP,cellIDCreationMP):
+
+    return (creationIndexMP << 32) + cellIDCreationMP
+
+#-------------------------------------------------------------------------------
+
+def check_particles_moved(particleFile0,
+                          particleFile1,
+                          logFile=None):
+
+    file1 = Dataset(particleFile0,"r")
+    file2 = Dataset(particleFile1,"r")
+
+    nParticles1 = len(file1.dimensions["nParticles"])
+    nParticles2 = len(file2.dimensions["nParticles"])
+
+    statusMP1 = file1.variables["statusMP"][0,:]
+    statusMP2 = file2.variables["statusMP"][0,:]
+    nParticlesStatus1 = np.count_nonzero(statusMP1)
+    nParticlesStatus2 = np.count_nonzero(statusMP2)
+
+    creationIndexMP1  = file1.variables["creationIndexMP"][0,:]
+    cellIDCreationMP1 = file1.variables["cellIDCreationMP"][0,:]
+
+    creationIndexMP2  = file2.variables["creationIndexMP"][0,:]
+    cellIDCreationMP2 = file2.variables["cellIDCreationMP"][0,:]
+
+    posnMP0 = file1.variables["posnMP"][:]
+    posnMP1 = file2.variables["posnMP"][:]
+
+    file1.close()
+    file2.close()
+
+    globalID1 = []
+    globalID2 = []
+    for iParticle in range(0,nParticles1):
+        if (statusMP1[iParticle] == 1):
+            globalID = set_globalID(creationIndexMP1[iParticle],cellIDCreationMP1[iParticle])
+            globalID1.append(globalID)
+    for iParticle in range(0,nParticles2):
+        if (statusMP2[iParticle] == 1):
+            globalID = set_globalID(creationIndexMP2[iParticle],cellIDCreationMP2[iParticle])
+            globalID2.append(globalID)
+    globalID1 = np.array(globalID1)
+    globalID2 = np.array(globalID2)
+    particlesOrder1 = np.argsort(globalID1)
+    particlesOrder2 = np.argsort(globalID2)
+
+    posnMP0 = posnMP0[0,(statusMP1 == 1)][particlesOrder1]
+    posnMP1 = posnMP1[0,(statusMP2 == 1)][particlesOrder2]
+
+    if (posnMP0.shape != posnMP1.shape):
+        message = "check_particles_moved: posnMP0.shape != posnMP1.shape"
+        log_message(message, "red", logFile=logFile)
+        raise Exception(message)
+
+    if (np.array_equal(posnMP0,posnMP1)):
+        message = "check_particles_moved: Particles did not apparently move: "+particleFile0+" to "+particleFile1
+        log_message(message, "red", logFile=logFile)
+        raise Exception(message)
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--p0', dest='particleFile0', required=True)
+    parser.add_argument('--p1', dest='particleFile1', required=True)
+
+    args = parser.parse_args()
+
+    check_particles_moved(args.particleFile0,
+                          args.particleFile1)

--- a/testcases/MPM/velocity_advection_test/create_ics.py
+++ b/testcases/MPM/velocity_advection_test/create_ics.py
@@ -1,0 +1,226 @@
+from netCDF4 import Dataset
+import numpy as np
+import math
+from math import sin, cos
+
+#-------------------------------------------------------------------------------
+
+def wind_stress_analytical(lat, earthRadius):
+
+    stressx = 0.0
+    stressy = cos(lat) * sin(lat) / earthRadius
+
+    return stressx, stressy
+
+#-------------------------------------------------------------------------------
+
+def grid_rotation_forward(x, y, z, rotateCartesianGrid):
+
+# rotate xyz coordinates from geographical grid to rotated grid with poles on real equator
+
+    if (rotateCartesianGrid):
+
+       xp = -z
+       yp = y
+       zp = x
+
+    else:
+
+       xp = x
+       yp = y
+       zp = z
+
+    return xp, yp, zp
+
+#-------------------------------------------------------------------------------
+
+def latlon_from_xyz(x, y, z, r):
+
+# given xyz coordinates determine the latitude and longitude
+
+    lon = math.atan2(y, x)
+    lat = math.asin(z/r)
+
+    return lat, lon
+
+#-------------------------------------------------------------------------------
+
+def latlon_vector_to_xyz_vector(u, v, lat, lon):
+
+# convert a latlon vector to a xyz vector
+
+    vx = (-u) * math.sin(lon) - v * math.sin(lat) * math.cos(lon)
+    vy =   u  * math.cos(lon) - v * math.sin(lat) * math.sin(lon)
+    vz =                        v * math.cos(lat)
+
+    return vx, vy, vz
+
+#-------------------------------------------------------------------------------
+
+def xyz_vector_to_latlon_vector(vx, vy, vz, lat, lon):
+
+# convert a xyz vector vector to a latlon vector
+
+    u = (-math.sin(lon)) * vx + math.cos(lon)  * vy
+
+    v = (-math.sin(lat)) * math.cos(lon) * vx + (-math.sin(lat)) * math.sin(lon) * vy + math.cos(lat)  * vz
+
+    return u, v
+
+#-------------------------------------------------------------------------------
+
+def xyz_vector_rotation_forward(vx, vy, vz, rotateCartesianGrid):
+
+# rotate a xyz vector from geographical grid to rotated grid with poles on real equator
+
+    if (rotateCartesianGrid):
+
+       vxp = -vz
+       vyp =  vy
+       vzp =  vx
+
+    else:
+
+       vxp = vx
+       vyp = vy
+       vzp = vz
+
+    return vxp, vyp, vzp
+
+#-------------------------------------------------------------------------------
+
+def latlon_vector_rotation_forward(u, v, lat, lon, x, y, z, r, rotateCartesianGrid):
+
+# rotate a latlon vector from geographical grid to rotated grid with poles on real equator
+
+# u, v are components of velocity on the geographical grid
+# lat, lon are lat/lon of point on the geographical grid
+# x, y, z position of the point on the geographical grid
+# r  is earth radius
+
+    # perform rotation of the point from geographical grid to rotated grid
+    xp, yp, zp = grid_rotation_forward(x, y, z, rotateCartesianGrid)
+
+    # calculate latitude and longitude of the point in the rotated grid
+    latp, lonp = latlon_from_xyz(xp, yp, zp, r)
+
+    # convert lat lon vector to xyz vector on gegraphical grid
+    vx, vy, vz = latlon_vector_to_xyz_vector(u, v, lat, lon)
+
+    # perform rotation of geographical xyz vector to rotated grid
+    vxp, vyp, vzp = xyz_vector_rotation_forward(vx, vy, vz, rotateCartesianGrid)
+
+    # convert xyz vector to lat lon vector on rotated grid
+    up, vp = xyz_vector_to_latlon_vector(vxp, vyp, vzp, latp, lonp)
+
+    return up, vp
+
+#-------------------------------------------------------------------------------
+
+def create_ics(earthRadius, rotateCartesianGrid):
+
+    forceTypes = ["cos_lat"]
+
+    gridSizes = [2562, 10242, 40962, 163842]
+
+    iceDensity = 917.0
+
+    for forceType in forceTypes:
+
+        print("Mesh IC, forceType for velocity: ", forceType)
+
+        for gridSize in gridSizes:
+
+            print("  Gridsize: ", gridSize)
+
+            # input
+            filenameIn = "grid.%i.nc" %(gridSize)
+
+            fileIn = Dataset(filenameIn,"r")
+
+            nCells = len(fileIn.dimensions["nCells"])
+            nVertices = len(fileIn.dimensions["nVertices"])
+
+            cellsOnVertex = fileIn.variables["cellsOnVertex"][:,:]
+
+            xVertex = fileIn.variables["xVertex"][:]
+            yVertex = fileIn.variables["yVertex"][:]
+            zVertex = fileIn.variables["zVertex"][:]
+
+            xCell = fileIn.variables["xCell"][:]
+            yCell = fileIn.variables["yCell"][:]
+            zCell = fileIn.variables["zCell"][:]
+
+            latCell = fileIn.variables["latCell"][:]
+
+            latVertex = fileIn.variables["latVertex"][:]
+            lonVertex = fileIn.variables["lonVertex"][:]
+
+            fileIn.close()
+
+            # output
+            filenameOut = "ic_%s_%i.nc" %(forceType, gridSize)
+
+            fileOut = Dataset(filenameOut, "w", format="NETCDF3_CLASSIC")
+
+            fileOut.createDimension("nCells", nCells)
+            fileOut.createDimension("nVertices", nVertices)
+            fileOut.createDimension("nCategories", size=1)
+            fileOut.createDimension("ONE", size=1)
+
+            # ice area and volume
+            #iceAreaCell = np.zeros(nCells)
+            #iceVolumeCell = np.zeros(nCells)
+            #iceAreaCategory = np.zeros([nCells, 1])
+            #iceVolumeCategory = np.zeros([nCells, 1])
+
+            #for iCell in range (0, nCells):
+            #    iceAreaCell[iCell] = 1.0
+            #    iceVolumeCell[iCell] = 1.0
+
+            #var = fileOut.createVariable("iceAreaCell",   'd', dimensions=("nCells"))
+            #var[:] = iceAreaCell[:]
+            #var = fileOut.createVariable("iceVolumeCell", 'd', dimensions=("nCells"))
+            #var[:] = iceVolumeCell[:]
+
+            #iceAreaCategory[:,0]   = iceAreaCell[:]
+            #var = fileOut.createVariable("iceAreaCategory",   'd', dimensions=("nCells","nCategories","ONE"))
+            #var[:] = iceAreaCategory
+
+            #iceVolumeCategory[:,0] = iceVolumeCell[:]
+            #var = fileOut.createVariable("iceVolumeCategory", 'd', dimensions=("nCells","nCategories","ONE"))
+            #var[:] = iceVolumeCategory
+
+            # wind_stress
+            airStressVertexU = np.zeros(nVertices)
+            airStressVertexV = np.zeros(nVertices)
+
+            for iVertex in range(0, nVertices):
+
+                lat, lon = latlon_from_xyz(xVertex[iVertex], yVertex[iVertex], zVertex[iVertex], earthRadius)
+
+                stressx, stressy = wind_stress_analytical(lat, earthRadius)
+
+                stressx, stressy = latlon_vector_rotation_forward(
+                                       stressx, stressy,
+                                       lat, lon,
+                                       xVertex[iVertex], yVertex[iVertex], zVertex[iVertex],
+                                       earthRadius, rotateCartesianGrid)
+
+                airStressVertexU[iVertex] = 40.0 * iceDensity * stressx
+                airStressVertexV[iVertex] = 40.0 * iceDensity * stressy
+
+
+            var = fileOut.createVariable("airStressVertexU","d",dimensions=["nVertices"])
+            var[:] = airStressVertexU[:]
+
+            var = fileOut.createVariable("airStressVertexV","d",dimensions=["nVertices"])
+            var[:] = airStressVertexV[:]
+
+            fileOut.close()
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    create_ics(earthRadius, rotateCartesianGrid)

--- a/testcases/MPM/velocity_advection_test/create_particles.py
+++ b/testcases/MPM/velocity_advection_test/create_particles.py
@@ -1,0 +1,42 @@
+import sys
+
+sys.path.append("../../../utils/MPM/particle_initialization/")
+from initial_particle_positions import initial_particle_positions
+
+import os
+
+#--------------------------------------------------------------------
+
+def create_particles():
+
+    reses = ["2562","10242","40962","163842"]
+
+    icTypes = ["cap"]
+
+    for icType in icTypes:
+
+        print("icType: ", icType)
+
+        for res in reses:
+
+            print("  Res: ", res)
+
+            filenameOut = "particles_%s.nc" %(res)
+
+            if (not os.path.isfile(filenameOut)):
+
+                filenameMesh = "grid.%s.nc" %(res)
+
+                initial_particle_positions(filenameMesh,
+                                           filenameOut,
+                                           "number",
+                                           9,
+                                           "onePerEdge",
+                                           icType,
+                                           6371229.0)
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    create_particles()

--- a/testcases/MPM/velocity_advection_test/namelist.seaice.advection_convergence
+++ b/testcases/MPM/velocity_advection_test/namelist.seaice.advection_convergence
@@ -1,0 +1,548 @@
+&seaice_model
+    config_dt = 3600.0
+    config_calendar_type = 'noleap'
+    config_start_time = '2000-01-01_00:00:00'
+    config_stop_time = 'none'
+    config_run_duration = '02_00:00:00'
+    config_num_halos = 2
+/
+&io
+    config_pio_num_iotasks = 0
+    config_pio_stride = 1
+    config_write_output_on_startup = true
+    config_test_case_diag = false
+    config_test_case_diag_type = 'none'
+    config_full_abort_write = true
+/
+&decomposition
+    config_block_decomp_file_prefix = 'graphs/graph.info.part.'
+    config_number_of_blocks = 0
+    config_explicit_proc_decomp = false
+    config_proc_decomp_file_prefix = 'graphs/graph.info.part.'
+    config_use_halo_exch = true
+    config_aggregate_halo_exch = false
+    config_reuse_halo_exch = false
+    config_load_balance_timers = false
+/
+&restart
+    config_do_restart = false
+    config_restart_timestamp_name = 'restart_timestamp'
+    config_do_restart_hbrine = false
+    config_do_restart_zsalinity = false
+    config_do_restart_bgc = false
+    config_do_restart_snow_density = false
+    config_do_restart_snow_grain_radius = false
+/
+&dimensions
+    config_nCategories = 1
+    config_nFloeCategories = 1
+    config_nIceLayers = 7
+    config_nSnowLayers = 1
+/
+&initialize
+    config_earth_radius = 6371229.0
+    config_initial_condition_type = 'none'
+    config_initial_ice_area = 1.0
+    config_initial_ice_volume = 1.0
+    config_initial_snow_volume = 0.0
+    config_initial_latitude_north = 70.0
+    config_initial_latitude_south = -60.0
+    config_initial_velocity_type = 'none'
+    config_initial_uvelocity = 0.0
+    config_initial_vvelocity = 0.0
+    config_calculate_coriolis = true
+/
+&use_sections
+    config_use_dynamics = true
+    config_use_velocity_solver = true
+    config_use_advection = true
+    config_use_mpm = true
+    config_use_forcing = false
+    config_use_column_physics = false
+    config_use_prescribed_ice = false
+    config_use_prescribed_ice_forcing = false
+/
+&forcing
+    config_atmospheric_forcing_type = 'CORE'
+    config_forcing_start_time = '2000-01-01_00:00:00'
+    config_forcing_cycle_start = '2000-01-01_00:00:00'
+    config_forcing_cycle_duration = '2-00-00_00:00:00'
+    config_forcing_precipitation_units = 'mm_per_sec'
+    config_forcing_sst_type = 'ncar'
+    config_forcing_bgc_type = 'ISPOL'
+    config_update_ocean_fluxes = false
+    config_frazil_coupling_type = 'external'
+    config_include_pond_freshwater_feedback = false
+/
+&testing
+    config_use_test_ice_shelf = false
+    config_testing_system_test = false
+    config_use_congelation_basal_melt = true
+    config_use_lateral_melt = true
+    config_use_latent_processes = true
+    config_limit_air_temperatures = true
+/
+&velocity_solver
+    config_dynamics_subcycle_number = 1
+    config_rotate_cartesian_grid = true
+    config_include_metric_terms = true
+    config_elastic_subcycle_number = 120
+    config_strain_scheme = 'mpm'
+    config_constitutive_relation_type = 'evp'
+    config_stress_divergence_scheme = 'variational'
+    config_variational_basis = 'wachspress'
+    config_variational_denominator_type = 'original'
+    config_wachspress_integration_type = 'dunavant'
+    config_wachspress_integration_order = 8
+    config_calc_velocity_masks = true
+    config_average_variational_strain = false
+    config_use_air_stress = false
+    config_use_ocean_stress = false
+    config_use_surface_tilt = false
+    config_geostrophic_surface_tilt = false
+    config_ocean_stress_type = 'quadratic'
+    config_use_special_boundaries_velocity = false
+    config_use_special_boundaries_velocity_masks = false
+/
+&advection
+    config_advection_type = 'mpm'
+    config_monotonic = true
+    config_conservation_check = false
+    config_monotonicity_check = false
+    config_recover_tracer_means_check = false
+/
+&mpm
+    config_use_mpm_velocity_solver = true
+    config_use_mpm_freeze_melt = false
+    config_use_mpm_polympo = false
+    config_mpm_create_particles = false
+    config_mpm_particle_init_type = 'number'
+    config_mpm_particle_posn_init_type = 'even'
+    config_mpm_particle_init_number = 9
+    config_mpm_particle_block_size = 128
+    config_mpm_assembly_test = false
+    config_mpm_polympo_init_test = false
+/
+&column_package
+    config_column_physics_type = 'icepack'
+    config_column_element_type = 'particles'
+    config_use_column_shortwave = true
+    config_use_column_vertical_thermodynamics = true
+    config_use_column_biogeochemistry = false
+    config_use_column_itd_thermodynamics = true
+    config_use_column_ridging = true
+    config_use_column_snow_tracers = false
+/
+&column_tracers
+    config_use_ice_age = true
+    config_use_first_year_ice = true
+    config_use_level_ice = true
+    config_use_cesm_meltponds = false
+    config_use_level_meltponds = true
+    config_use_topo_meltponds = false
+    config_use_aerosols = false
+    config_use_effective_snow_density = false
+    config_use_snow_grain_radius = false
+    config_use_special_boundaries_tracers = false
+    config_use_floe_size_distribution = false
+/
+&biogeochemistry
+    config_use_brine = false
+    config_use_vertical_zsalinity = false
+    config_use_vertical_biochemistry = false
+    config_use_shortwave_bioabsorption = false
+    config_use_vertical_tracers = false
+    config_use_skeletal_biochemistry = false
+    config_use_nitrate = false
+    config_use_carbon = false
+    config_use_chlorophyll = false
+    config_use_ammonium = false
+    config_use_silicate = false
+    config_use_DMS = false
+    config_use_nonreactive = false
+    config_use_humics = false
+    config_use_DON = false
+    config_use_iron = false
+    config_use_macromolecules = false
+    config_use_modal_aerosols = false
+    config_use_zaerosols = false
+    config_skeletal_bgc_flux_type = 'Jin2006'
+    config_scale_initial_vertical_bgc = false
+    config_biogrid_bottom_molecular_sublayer = 0.006
+    config_biogrid_top_molecular_sublayer = 0.006
+    config_bio_gravity_drainage_length_scale = 0.024
+    config_zsalinity_molecular_sublayer = 0.0
+    config_zsalinity_gravity_drainage_scale = 0.028
+    config_snow_porosity_at_ice_surface = -0.3
+    config_new_ice_fraction_biotracer = 0.80
+    config_fraction_biotracer_in_frazil = 0.80
+    config_ratio_Si_to_N_diatoms = 1.80
+    config_ratio_Si_to_N_small_plankton = 0.00
+    config_ratio_Si_to_N_phaeocystis = 0.00
+    config_ratio_S_to_N_diatoms = 0.03
+    config_ratio_S_to_N_small_plankton = 0.03
+    config_ratio_S_to_N_phaeocystis = 0.03
+    config_ratio_Fe_to_C_diatoms = 0.0033
+    config_ratio_Fe_to_C_small_plankton = 0.0033
+    config_ratio_Fe_to_C_phaeocystis = 0.1
+    config_ratio_Fe_to_N_diatoms = 0.023
+    config_ratio_Fe_to_N_small_plankton = 0.023
+    config_ratio_Fe_to_N_phaeocystis = 0.7
+    config_ratio_Fe_to_DON = 0.023
+    config_ratio_Fe_to_DOC_saccharids = 0.1
+    config_ratio_Fe_to_DOC_lipids = 0.033
+    config_respiration_fraction_of_growth = 0.05
+    config_rapid_mobile_to_stationary_time = 5200.0
+    config_long_mobile_to_stationary_time = 173000.0
+    config_algal_maximum_velocity = 0.0000000111
+    config_ratio_Fe_to_dust = 0.035
+    config_solubility_of_Fe_in_dust = 0.005
+    config_chla_absorptivity_of_diatoms = 0.03
+    config_chla_absorptivity_of_small_plankton = 0.01
+    config_chla_absorptivity_of_phaeocystis = 0.05
+    config_light_attenuation_diatoms = 0.8
+    config_light_attenuation_small_plankton = 0.67
+    config_light_attenuation_phaeocystis = 0.67
+    config_light_inhibition_diatoms = 0.018
+    config_light_inhibition_small_plankton = 0.0025
+    config_light_inhibition_phaeocystis = 0.01
+    config_maximum_growth_rate_diatoms = 1.44
+    config_maximum_growth_rate_small_plankton = 0.851
+    config_maximum_growth_rate_phaeocystis = 0.851
+    config_temperature_growth_diatoms = 0.06
+    config_temperature_growth_small_plankton = 0.06
+    config_temperature_growth_phaeocystis = 0.06
+    config_grazed_fraction_diatoms = 0.0
+    config_grazed_fraction_small_plankton = 0.1
+    config_grazed_fraction_phaeocystis = 0.1
+    config_mortality_diatoms = 0.007
+    config_mortality_small_plankton = 0.007
+    config_mortality_phaeocystis = 0.007
+    config_temperature_mortality_diatoms = 0.03
+    config_temperature_mortality_small_plankton = 0.03
+    config_temperature_mortality_phaeocystis = 0.03
+    config_exudation_diatoms = 0.0
+    config_exudation_small_plankton = 0.0
+    config_exudation_phaeocystis = 0.0
+    config_nitrate_saturation_diatoms = 1.0
+    config_nitrate_saturation_small_plankton = 1.0
+    config_nitrate_saturation_phaeocystis = 1.0
+    config_ammonium_saturation_diatoms = 0.3
+    config_ammonium_saturation_small_plankton = 0.3
+    config_ammonium_saturation_phaeocystis = 0.3
+    config_silicate_saturation_diatoms = 4.0
+    config_silicate_saturation_small_plankton = 0.0
+    config_silicate_saturation_phaeocystis = 0.0
+    config_iron_saturation_diatoms = 1.0
+    config_iron_saturation_small_plankton = 0.2
+    config_iron_saturation_phaeocystis = 0.1
+    config_fraction_spilled_to_DON = 0.6
+    config_degredation_of_DON = 0.03
+    config_fraction_DON_ammonium = 0.25
+    config_fraction_loss_to_saccharids = 0.4
+    config_fraction_loss_to_lipids = 0.4
+    config_fraction_exudation_to_saccharids = 1.0
+    config_fraction_exudation_to_lipids = 1.0
+    config_remineralization_saccharids = 0.03
+    config_remineralization_lipids = 0.03
+    config_maximum_brine_temperature = 0.0
+    config_salinity_dependence_of_growth = 1.0
+    config_minimum_optical_depth = 0.1
+    config_slopped_grazing_fraction = 0.5
+    config_excreted_fraction = 0.5
+    config_fraction_mortality_to_ammonium = 0.5
+    config_fraction_iron_remineralized = 0.3
+    config_nitrification_rate = 0.0
+    config_desorption_loss_particulate_iron = 3065.0
+    config_maximum_loss_fraction = 0.9
+    config_maximum_ratio_iron_to_saccharids = 0.2
+    config_respiration_loss_to_DMSPd = 0.75
+    config_DMSP_to_DMS_conversion_fraction = 0.5
+    config_DMSP_to_DMS_conversion_time = 3.0
+    config_DMS_oxidation_time = 10.0
+    config_mobility_type_diatoms = 0.0
+    config_mobility_type_small_plankton = 0.5
+    config_mobility_type_phaeocystis = 0.5
+    config_mobility_type_nitrate = -1.0
+    config_mobility_type_ammonium = 1.0
+    config_mobility_type_silicate = -1.0
+    config_mobility_type_DMSPp = 0.5
+    config_mobility_type_DMSPd = -1.0
+    config_mobility_type_humics = 1.0
+    config_mobility_type_saccharids = 0.5
+    config_mobility_type_lipids = 0.5
+    config_mobility_type_inorganic_carbon = -1.0
+    config_mobility_type_proteins = 0.5
+    config_mobility_type_dissolved_iron = 0.5
+    config_mobility_type_particulate_iron = 0.5
+    config_mobility_type_black_carbon1 = 1.0
+    config_mobility_type_black_carbon2 = 1.0
+    config_mobility_type_dust1 = 1.0
+    config_mobility_type_dust2 = 1.0
+    config_mobility_type_dust3 = 1.0
+    config_mobility_type_dust4 = 1.0
+    config_ratio_C_to_N_diatoms = 7.0
+    config_ratio_C_to_N_small_plankton = 7.0
+    config_ratio_C_to_N_phaeocystis = 7.0
+    config_ratio_chla_to_N_diatoms = 2.1
+    config_ratio_chla_to_N_small_plankton = 1.1
+    config_ratio_chla_to_N_phaeocystis = 0.84
+    config_scales_absorption_diatoms = 2.0
+    config_scales_absorption_small_plankton = 4.0
+    config_scales_absorption_phaeocystis = 5.0
+    config_ratio_C_to_N_proteins = 7.0
+/
+&shortwave
+    config_shortwave_type = 'dEdd'
+    config_albedo_type = 'ccsm3'
+    config_use_snicar_ad = false
+    config_visible_ice_albedo = 0.78
+    config_infrared_ice_albedo = 0.36
+    config_visible_snow_albedo = 0.98
+    config_infrared_snow_albedo = 0.70
+    config_variable_albedo_thickness_limit = 0.3
+    config_ice_shortwave_tuning_parameter = 0.0
+    config_pond_shortwave_tuning_parameter = 0.0
+    config_snow_shortwave_tuning_parameter = 1.5
+    config_temp_change_snow_grain_radius_change = 1.5
+    config_max_melting_snow_grain_radius = 1500.0
+    config_algae_absorption_coefficient = 0.6
+    config_use_shortwave_redistribution = false
+    config_shortwave_redistribution_fraction = 0.9
+    config_shortwave_redistribution_threshold = 0.02
+/
+&snow
+    config_snow_redistribution_scheme = 'none'
+    config_fallen_snow_radius = 54.526
+    config_use_snow_liquid_ponds = false
+    config_new_snow_density = 100.0
+    config_max_snow_density = 450.0
+    config_minimum_wind_compaction = 10.0
+    config_wind_compaction_factor = 27.3
+    config_snow_redistribution_factor = 0.3
+    config_max_dry_snow_radius = 1800.0
+    config_snow_thermal_conductivity = 0.3
+/
+&meltponds
+    config_snow_to_ice_transition_depth = 0.0
+    config_pond_refreezing_type = 'hlid'
+    config_pond_flushing_factor = 1.0e-3
+    config_min_meltwater_retained_fraction = 0.15
+    config_max_meltwater_retained_fraction = 1.0
+    config_pond_depth_to_fraction_ratio = 0.8
+    config_snow_on_pond_ice_tapering_parameter = 0.03
+    config_critical_pond_ice_thickness = 0.01
+/
+&thermodynamics
+    config_thermodynamics_type = 'mushy'
+    config_heat_conductivity_type = 'bubbly'
+    config_rapid_mode_channel_radius = 0.5e-3
+    config_rapid_model_critical_Ra = 10.0
+    config_rapid_mode_aspect_ratio = 1.0
+    config_slow_mode_drainage_strength = -5.0e-8
+    config_slow_mode_critical_porosity = 0.05
+    config_macro_drainage_timescale = 10.
+    config_congelation_ice_porosity = 0.85
+/
+&itd
+    config_itd_conversion_type = 'linear remap'
+    config_category_bounds_type = 'original'
+/
+&floesize
+    config_floeshape = 0.66
+    config_floediam = 300.0
+/
+&ridging
+    config_ice_strength_formulation = 'Rothrock75'
+    config_ridging_participation_function = 'exponential'
+    config_ridging_redistribution_function = 'exponential'
+    config_ridging_efolding_scale = 3.0
+    config_ratio_ridging_work_to_PE = 17.0
+/
+&atmosphere
+    config_atmos_boundary_method = 'similarity'
+    config_calc_surface_stresses = true
+    config_calc_surface_temperature = true
+    config_use_form_drag = false
+    config_use_high_frequency_coupling = false
+    config_boundary_layer_iteration_number = 5
+/
+&ocean
+    config_use_ocean_mixed_layer = true
+    config_ocean_mixed_layer_type = 'cice'
+    config_min_friction_velocity = 0.0005
+    config_ocean_heat_transfer_type = 'constant'
+    config_sea_freezing_temperature_type = 'mushy'
+    config_ocean_surface_type = 'free'
+    config_use_data_icebergs = false
+    config_salt_flux_coupling_type = 'constant'
+    config_ice_ocean_drag_coefficient = 0.00536
+/
+&diagnostics
+    config_check_state = false
+/
+&AM_highFrequencyOutput
+    config_AM_highFrequencyOutput_enable = false
+    config_AM_highFrequencyOutput_compute_interval = 'output_interval'
+    config_AM_highFrequencyOutput_output_stream = 'highFrequencyOutput'
+    config_AM_highFrequencyOutput_compute_on_startup = true
+    config_AM_highFrequencyOutput_write_on_startup = true
+/
+&AM_temperatures
+    config_AM_temperatures_enable = false
+    config_AM_temperatures_compute_interval = 'dt'
+    config_AM_temperatures_output_stream = 'none'
+    config_AM_temperatures_compute_on_startup = false
+    config_AM_temperatures_write_on_startup = false
+/
+&AM_regionalStatistics
+    config_AM_regionalStatistics_enable = false
+    config_AM_regionalStatistics_compute_interval = 'output_interval'
+    config_AM_regionalStatistics_output_stream = 'regionalStatisticsOutput'
+    config_AM_regionalStatistics_compute_on_startup = false
+    config_AM_regionalStatistics_write_on_startup = false
+    config_AM_regionalStatistics_ice_extent_limit = 0.15
+/
+&AM_ridgingDiagnostics
+    config_AM_ridgingDiagnostics_enable = false
+    config_AM_ridgingDiagnostics_compute_interval = 'dt'
+    config_AM_ridgingDiagnostics_output_stream = 'none'
+    config_AM_ridgingDiagnostics_compute_on_startup = false
+    config_AM_ridgingDiagnostics_write_on_startup = false
+/
+&AM_conservationCheck
+    config_AM_conservationCheck_enable = false
+    config_AM_conservationCheck_compute_interval = 'dt'
+    config_AM_conservationCheck_output_stream = 'conservationCheckOutput'
+    config_AM_conservationCheck_compute_on_startup = false
+    config_AM_conservationCheck_write_on_startup = false
+    config_AM_conservationCheck_write_to_logfile = true
+/
+&AM_geographicalVectors
+    config_AM_geographicalVectors_enable = false
+    config_AM_geographicalVectors_compute_interval = 'dt'
+    config_AM_geographicalVectors_output_stream = 'none'
+    config_AM_geographicalVectors_compute_on_startup = false
+    config_AM_geographicalVectors_write_on_startup = false
+/
+&AM_loadBalance
+    config_AM_loadBalance_enable = false
+    config_AM_loadBalance_compute_interval = 'output_interval'
+    config_AM_loadBalance_output_stream = 'loadBalanceOutput'
+    config_AM_loadBalance_compute_on_startup = false
+    config_AM_loadBalance_write_on_startup = false
+    config_AM_loadBalance_nProcs = 32
+/
+&AM_maximumIcePresence
+    config_AM_maximumIcePresence_enable = false
+    config_AM_maximumIcePresence_compute_interval = 'dt'
+    config_AM_maximumIcePresence_output_stream = 'maximumIcePresenceOutput'
+    config_AM_maximumIcePresence_compute_on_startup = false
+    config_AM_maximumIcePresence_write_on_startup = false
+    config_AM_maximumIcePresence_start_time = '0000-00-00_00:00:00'
+/
+&AM_miscellaneous
+    config_AM_miscellaneous_enable = false
+    config_AM_miscellaneous_compute_interval = 'dt'
+    config_AM_miscellaneous_output_stream = 'none'
+    config_AM_miscellaneous_compute_on_startup = false
+    config_AM_miscellaneous_write_on_startup = false
+/
+&AM_areaVariables
+    config_AM_areaVariables_enable = false
+    config_AM_areaVariables_compute_interval = 'dt'
+    config_AM_areaVariables_output_stream = 'none'
+    config_AM_areaVariables_compute_on_startup = false
+    config_AM_areaVariables_write_on_startup = false
+/
+&AM_pondDiagnostics
+    config_AM_pondDiagnostics_enable = false
+    config_AM_pondDiagnostics_compute_interval = 'dt'
+    config_AM_pondDiagnostics_output_stream = 'none'
+    config_AM_pondDiagnostics_compute_on_startup = false
+    config_AM_pondDiagnostics_write_on_startup = false
+/
+&AM_unitConversion
+    config_AM_unitConversion_enable = false
+    config_AM_unitConversion_compute_interval = 'dt'
+    config_AM_unitConversion_output_stream = 'none'
+    config_AM_unitConversion_compute_on_startup = false
+    config_AM_unitConversion_write_on_startup = false
+/
+&AM_pointwiseStats
+    config_AM_pointwiseStats_enable = false
+    config_AM_pointwiseStats_compute_interval = 'dt'
+    config_AM_pointwiseStats_output_stream = 'pointwiseStatsOutput'
+    config_AM_pointwiseStats_compute_on_startup = false
+    config_AM_pointwiseStats_write_on_startup = false
+/
+&AM_iceShelves
+    config_AM_iceShelves_enable = false
+    config_AM_iceShelves_compute_interval = 'output_interval'
+    config_AM_iceShelves_output_stream = 'iceShelvesOutput'
+    config_AM_iceShelves_compute_on_startup = true
+    config_AM_iceShelves_write_on_startup = true
+/
+&AM_icePresent
+    config_AM_icePresent_enable = false
+    config_AM_icePresent_compute_interval = 'dt'
+    config_AM_icePresent_output_stream = 'none'
+    config_AM_icePresent_compute_on_startup = false
+    config_AM_icePresent_write_on_startup = false
+/
+&AM_timeSeriesStatsDaily
+    config_AM_timeSeriesStatsDaily_enable = false
+    config_AM_timeSeriesStatsDaily_compute_on_startup = false
+    config_AM_timeSeriesStatsDaily_write_on_startup = false
+    config_AM_timeSeriesStatsDaily_compute_interval = 'dt'
+    config_AM_timeSeriesStatsDaily_output_stream = 'timeSeriesStatsDailyOutput'
+    config_AM_timeSeriesStatsDaily_restart_stream = 'timeSeriesStatsDailyRestart'
+    config_AM_timeSeriesStatsDaily_operation = 'avg'
+    config_AM_timeSeriesStatsDaily_reference_times = 'initial_time'
+    config_AM_timeSeriesStatsDaily_duration_intervals = 'repeat_interval'
+    config_AM_timeSeriesStatsDaily_repeat_intervals = 'reset_interval'
+    config_AM_timeSeriesStatsDaily_reset_intervals = '00-00-01_00:00:00'
+    config_AM_timeSeriesStatsDaily_backward_output_offset = '00-00-01_00:00:00'
+/
+&AM_timeSeriesStatsMonthly
+    config_AM_timeSeriesStatsMonthly_enable = false
+    config_AM_timeSeriesStatsMonthly_compute_on_startup = false
+    config_AM_timeSeriesStatsMonthly_write_on_startup = false
+    config_AM_timeSeriesStatsMonthly_compute_interval = 'dt'
+    config_AM_timeSeriesStatsMonthly_output_stream = 'timeSeriesStatsMonthlyOutput'
+    config_AM_timeSeriesStatsMonthly_restart_stream = 'timeSeriesStatsMonthlyRestart'
+    config_AM_timeSeriesStatsMonthly_operation = 'avg'
+    config_AM_timeSeriesStatsMonthly_reference_times = 'initial_time'
+    config_AM_timeSeriesStatsMonthly_duration_intervals = 'repeat_interval'
+    config_AM_timeSeriesStatsMonthly_repeat_intervals = 'reset_interval'
+    config_AM_timeSeriesStatsMonthly_reset_intervals = '00-01-00_00:00:00'
+    config_AM_timeSeriesStatsMonthly_backward_output_offset = '00-01-00_00:00:00'
+/
+&AM_timeSeriesStatsClimatology
+    config_AM_timeSeriesStatsClimatology_enable = false
+    config_AM_timeSeriesStatsClimatology_compute_on_startup = false
+    config_AM_timeSeriesStatsClimatology_write_on_startup = false
+    config_AM_timeSeriesStatsClimatology_compute_interval = '00-00-00_01:00:00'
+    config_AM_timeSeriesStatsClimatology_output_stream = 'timeSeriesStatsClimatologyOutput'
+    config_AM_timeSeriesStatsClimatology_restart_stream = 'timeSeriesStatsClimatologyRestart'
+    config_AM_timeSeriesStatsClimatology_operation = 'avg'
+    config_AM_timeSeriesStatsClimatology_reference_times = '00-03-01_00:00:00;00-06-01_00:00:00;00-09-01_00:00:00;00-12-01_00:00:00'
+    config_AM_timeSeriesStatsClimatology_duration_intervals = '00-03-00_00:00:00;00-03-00_00:00:00;00-03-00_00:00:00;00-03-00_00:00:00'
+    config_AM_timeSeriesStatsClimatology_repeat_intervals = '01-00-00_00:00:00;01-00-00_00:00:00;01-00-00_00:00:00;01-00-00_00:00:00'
+    config_AM_timeSeriesStatsClimatology_reset_intervals = '1000-00-00_00:00:00;1000-00-00_00:00:00;1000-00-00_00:00:00;1000-00-00_00:00:00'
+    config_AM_timeSeriesStatsClimatology_backward_output_offset = '00-03-00_00:00:00'
+/
+&AM_timeSeriesStatsCustom
+    config_AM_timeSeriesStatsCustom_enable = false
+    config_AM_timeSeriesStatsCustom_compute_on_startup = false
+    config_AM_timeSeriesStatsCustom_write_on_startup = false
+    config_AM_timeSeriesStatsCustom_compute_interval = '00-00-00_01:00:00'
+    config_AM_timeSeriesStatsCustom_output_stream = 'timeSeriesStatsCustomOutput'
+    config_AM_timeSeriesStatsCustom_restart_stream = 'timeSeriesStatsCustomRestart'
+    config_AM_timeSeriesStatsCustom_operation = 'avg'
+    config_AM_timeSeriesStatsCustom_reference_times = 'initial_time'
+    config_AM_timeSeriesStatsCustom_duration_intervals = 'repeat_interval'
+    config_AM_timeSeriesStatsCustom_repeat_intervals = 'reset_interval'
+    config_AM_timeSeriesStatsCustom_reset_intervals = '00-00-07_00:00:00'
+    config_AM_timeSeriesStatsCustom_backward_output_offset = '00-00-01_00:00:00'
+/

--- a/testcases/MPM/velocity_advection_test/parse_time_string.py
+++ b/testcases/MPM/velocity_advection_test/parse_time_string.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from netCDF4 import date2num
+
+#--------------------------------------------------------------------
+
+def parse_time_string(xtime):
+
+    date = datetime.strptime(b''.join(xtime.compressed()).decode('utf-8'),"%Y-%m-%d_%H:%M:%S")
+    secs = date2num(date, units='secs since 2000-01-01',
+                                         calendar='noleap')
+    return secs
+
+#--------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parse_time_string(xtime)

--- a/testcases/MPM/velocity_advection_test/plot_transport.py
+++ b/testcases/MPM/velocity_advection_test/plot_transport.py
@@ -1,0 +1,88 @@
+from netCDF4 import Dataset
+import matplotlib.pyplot as plt
+import math
+from mpl_toolkits import mplot3d
+import numpy as np
+from mpl_toolkits.mplot3d.art3d import Line3DCollection
+import glob
+import argparse
+
+#-------------------------------------------------------------------------------
+
+def plot_file(filenameIn, filenameOut):
+
+    iTime = 0
+
+    filein = Dataset(filenameIn,"r")
+
+    sphere_radius = filein.sphere_radius
+
+    nParticles = len(filein.dimensions["nParticles"])
+
+    posnMP = filein.variables["posnMP"][:]
+
+    procIDParticle = filein.variables["procIDParticle"][:]
+
+    indexToCellIDParticle = filein.variables["indexToCellIDParticle"][:]
+
+    nValid = 0
+    valid = []
+    colors = []
+    for iParticle in range(0,nParticles):
+        mag = math.sqrt(math.pow(posnMP[iTime,iParticle,0],2) + \
+                        math.pow(posnMP[iTime,iParticle,1],2) + \
+                        math.pow(posnMP[iTime,iParticle,2],2))
+        if (mag > 1e-8):
+            nValid += 1
+            valid.append(True)
+            colors.append(procIDParticle[iTime,iParticle])
+        else:
+            valid.append(False)
+
+
+
+    filein.close()
+
+    fig, axis = plt.subplots(subplot_kw={'projection':'3d'})
+
+    axis.scatter(posnMP[iTime,valid,0],posnMP[iTime,valid,1],posnMP[iTime,valid,2],c=colors)
+
+    axis.set_xlim((-1.1*sphere_radius,1.1*sphere_radius))
+    axis.set_ylim((-1.1*sphere_radius,1.1*sphere_radius))
+    axis.set_zlim((-1.1*sphere_radius,1.1*sphere_radius))
+
+    axis.set_xlabel("x")
+    axis.set_ylabel("y")
+    axis.set_zlabel("z")
+
+    plt.savefig(filenameOut)
+    plt.cla()
+    plt.close(fig)
+
+
+    return nValid
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Plot the MPM advection test case')
+
+    parser.add_argument('-f', required=True, dest='filenameTemplate', help='filename template for particle files')
+
+    args = parser.parse_args()
+
+    nskip = 1
+
+    filenames = sorted(glob.glob(args.filenameTemplate))
+
+    iFile = 0
+    for filenameIn in filenames[::nskip]:
+        print(filenameIn)
+
+        filenameOut = "./plots/plot_transport_%4.4i.png" %(iFile)
+
+        nValid = plot_file(filenameIn, filenameOut)
+
+        print(filenameOut, nValid)
+        iFile += 1

--- a/testcases/MPM/velocity_advection_test/run_model.py
+++ b/testcases/MPM/velocity_advection_test/run_model.py
@@ -1,0 +1,64 @@
+import sys
+
+sys.path.append("../../../utils/testcases")
+from execute_model import execute_model
+
+import os
+try:
+    import f90nml
+except ImportError:
+    print("Module f90nml needed and not available")
+    raise
+
+#-------------------------------------------------------------------------------
+
+def run_model(usePolympo,
+              logFile=None):
+
+    MPAS_SEAICE_EXECUTABLE = os.environ.get('MPAS_SEAICE_EXECUTABLE')
+    if (MPAS_SEAICE_EXECUTABLE is None):
+        MPAS_SEAICE_EXECUTABLE = "../../../../MPAS-Seaice-MPM/components/mpas-seaice/seaice_model"
+        print("Using executable in standard location: %s" %(MPAS_SEAICE_EXECUTABLE))
+
+    forceTypes = ["cos_lat"]
+
+    gridSizes = [2562, 10242, 40962, 163842]
+    #gridSizes = [2562]
+
+    if (usePolympo):
+         usePolympoStr = "polympo"
+    else:
+         usePolympoStr = "nonpolympo"
+
+    for forceType in forceTypes:
+
+         for gridSize in gridSizes:
+
+             print()
+             message = "Forcing for: %s solution, Gridsize: %i" %(forceType, gridSize)
+             print(message)
+             print("-"*len(message))
+
+             if (not os.path.isdir("output")):
+                 os.mkdir("output")
+
+             os.system("rm grid.nc ic.nc particles.nc namelist.seaice")
+             os.system("ln -s namelist.seaice.%s.%i namelist.seaice" %(usePolympoStr, gridSize))
+             os.system("ln -s grid.%i.nc grid.nc" %(gridSize))
+             os.system("ln -s ic_%s_%i.nc ic.nc" %(forceType, gridSize))
+             os.system("ln -s particles_%i.nc particles.nc" %(gridSize))
+
+             os.system("rm -rf output_%s_%i_%s" %(forceType, gridSize, usePolympoStr))
+
+             execute_model(MPAS_SEAICE_EXECUTABLE,
+                           1,
+                           logFile)
+
+             os.system("mv output output_%s_%i_%s" %(forceType, gridSize, usePolympoStr))
+             os.system("mv log.seaice.0000.out log.seaice.0000.out_%s_%i_%s" %(forceType, gridSize, usePolympoStr))
+
+#-----------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    run_model(False)

--- a/testcases/MPM/velocity_advection_test/run_testcase.py
+++ b/testcases/MPM/velocity_advection_test/run_testcase.py
@@ -1,0 +1,113 @@
+import sys
+
+sys.path.append("../../../utils/testcases")
+from get_testcase_data_spherical import get_testcase_data_spherical
+from create_ics import create_ics
+from create_particles import create_particles
+from add_uvVelMP_to_particles_file import add_uvVelMP_to_particles_file
+from run_model import run_model
+from advection_error_convergence import advection_error_convergence
+
+sys.path.append("../advection")
+from check_particles_moved import check_particles_moved
+
+sys.path.append("../../../testing")
+from testing_utils import create_new_namelist
+
+import math
+import f90nml
+import argparse
+
+#-------------------------------------------------------------------------------
+
+def run_testcase(logFilename=None):
+
+    if (logFilename is not None):
+        logFile = open(logFilename,"a")
+        logFile.write("\n Velocity Advection convergence test case\n")
+        logFile.write(  "===============================\n")
+        logFile.flush()
+    else:
+        logFile = None
+
+    reses = ["2562", "10242", "40962", "163842"]
+    #reses = ["2562"]
+    forceTypes = ["cos_lat"]
+    DynamicsTimeStep = [3600.0, 1800.0, 900.0, 450.0]
+    rotateCartesianGrid = True
+    earthRadius = 6371229.0
+
+    #usePolympos = [False, True]
+    usePolympos = [False]
+
+    print("Get testcase data")
+    print("=================")
+    get_testcase_data_spherical()
+
+    print("\nCreate ICs")
+    print("==========")
+    create_ics(earthRadius, rotateCartesianGrid)
+
+    print("\nCreate particles")
+    print("================")
+    create_particles()
+
+    print("\nAdd uvVelMP to particles file")
+    print("================")
+    add_uvVelMP_to_particles_file(earthRadius, rotateCartesianGrid)
+
+    print("\nCreate namelists")
+    print("================")
+
+    for usePolympo in usePolympos:
+
+        print("usePolympo: ", usePolympo)
+        if (usePolympo):
+            usePolympoStr = "polympo"
+        else:
+            usePolympoStr = "nonpolympo"
+
+        r = 0
+        for res in reses:
+
+            nmlChanges = {"mpm":{"config_use_mpm_polympo":usePolympo},
+                          "seaice_model":{"config_dt":DynamicsTimeStep[r]}}
+
+            new_namelist = "namelist.seaice.%s.%s" %(usePolympoStr, res)
+            create_new_namelist("namelist.seaice.advection_convergence", new_namelist, nmlChanges)
+
+            r = r + 1
+
+        print("\nRun models")
+        print("==========")
+        run_model(usePolympo,
+                  logFile)
+
+        print("\nCheck particles moved")
+        print("=====================")
+        particleFilename1 = "particles_output.2000-01-01_00.00.00.nc"
+        particleFilename2 = "particles_output.2000-01-01_04.00.00.nc"
+
+        for forceType in forceTypes:
+            for res in reses:
+
+                check_particles_moved("./output_"+forceType+"_"+res+"_"+usePolympoStr+"/"+particleFilename1,
+                                      "./output_"+forceType+"_"+res+"_"+usePolympoStr+"/"+particleFilename2,
+                                      logFile)
+
+        print("\nAdvection error convergence")
+        print("===========================")
+
+        advection_error_convergence(usePolympoStr, logFile)
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-l', dest='logFilename')
+
+    args = parser.parse_args()
+
+    run_testcase(args.logFilename)

--- a/testcases/MPM/velocity_advection_test/streams.seaice
+++ b/testcases/MPM/velocity_advection_test/streams.seaice
@@ -1,0 +1,374 @@
+<streams>
+<immutable_stream name="mesh"
+                  type="none"
+                  filename_template="mesh_variables.nc" />
+
+<immutable_stream name="input"
+                  type="input"
+                  filename_template="grid.nc"
+                  filename_interval="none"
+                  input_interval="initial_only" />
+
+<immutable_stream name="particleInput"
+                  type="input"
+                  filename_template="particles.nc"
+                  filename_interval="none"
+                  input_interval="initial_only" />
+
+<stream name="initialConditions"
+        type="input"
+        filename_template="ic.nc"
+        filename_interval="none"
+        input_interval="initial_only">
+
+        <var name="uVelocity"/>
+        <var name="vVelocity"/>
+	<var name="iceAreaCell"/>
+	<var name="iceVolumeCell"/>
+	<var name="iceAreaCategory"/>
+	<var name="iceVolumeCategory"/>
+        <var name="deluDyn"/>
+        <var name="uvVelMP"/>
+</stream>
+
+<immutable_stream name="restart"
+                  type="input;output"
+                  filename_template="restarts/restart.$Y-$M-$D_$h.$m.$s.nc"
+                  filename_interval="00_00:00:01"
+		  clobber_mode="replace_files"
+                  input_interval="initial_only"
+                  output_interval="00-03-00_00:00:00" />
+
+<stream name="output"
+        type="output"
+        filename_template="output/output.$Y.nc"
+        filename_interval="01-00-00_00:00:00"
+        clobber_mode="replace_files"
+        output_interval="00-00-00_04:00:00" >
+
+	<var name="xtime"/>
+	<var name="daysSinceStartOfSim"/>
+	<stream name="mesh"/>
+	<var name="iceAreaCell"/>
+	<var name="iceVolumeCell"/>
+	<var name="snowVolumeCell"/>
+	<var name="uVelocity"/>
+	<var name="vVelocity"/>
+	<var name="uVelocityGeo"/>
+	<var name="vVelocityGeo"/>
+        <var name="procID"/>
+        <var name="totalMassVertex"/>
+</stream>
+
+<stream name="particlesOut"
+        type="output"
+        filename_template="output/particles_output.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="00-00-00_00:00:01"
+        clobber_mode="replace_files"
+        output_interval="00-00-00_04:00:00" >
+
+	<var name="xtime"/>
+	<var name="statusMP"/>
+	<var name="iCellMP"/>
+        <var name="cellIDCreationMP"/>
+        <var name="creationIndexMP"/>
+        <var name="indexToCellIDMP"/>
+        <var name="procIDParticle"/>
+        <var name="posnMP"/>
+        <var name="iceAreaCellMP"/>
+        <var name="uvVelMP"/>
+</stream>
+
+<immutable_stream name="LYqSixHourlyForcing"
+                  type="input"
+                  filename_template="forcing/atmosphere_forcing_six_hourly.$Y.nc"
+                  filename_interval="0001-00-00_00:00:00"
+		  reference_time="2000-01-01_03:00:00"
+                  input_interval="none" />
+
+<immutable_stream name="LYqMonthlyForcing"
+                  type="input"
+                  filename_template="forcing/atmosphere_forcing_monthly.nc"
+                  filename_interval="none"
+                  input_interval="none" />
+
+<immutable_stream name="NCARMonthlySSTForcing"
+                  type="input"
+                  filename_template="forcing/ocean_forcing_monthly.nc"
+                  filename_interval="none"
+                  input_interval="none" />
+
+<immutable_stream name="NCARMonthlyForcing"
+                  type="input"
+                  filename_template="forcing/ocean_forcing_monthly.nc"
+                  filename_interval="none"
+                  input_interval="none" />
+
+<stream name="dataIcebergForcing"
+                  type="input"
+                  filename_template="forcing/data_icebergs.nc"
+                  filename_interval="none"
+                  input_interval="none" >
+    <var name="bergFreshwaterFluxData"/>
+    <var name="xtime" />
+</stream>
+
+<stream name="abort_block"
+        type="output"
+        filename_template="abort_seaice_$Y-$M-$D_$h.$m.$s_block_$B.nc"
+        filename_interval="none"
+        clobber_mode="truncate"
+        output_interval="none" >
+
+	<stream name="mesh"/>
+	<stream name="abort_contents"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="xtime"/>
+</stream>
+
+<stream name="abort"
+        type="output"
+        filename_template="abort_seaice_$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="none"
+        clobber_mode="truncate"
+        output_interval="none" >
+
+	<stream name="mesh"/>
+	<stream name="abort_contents"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="xtime"/>
+</stream>
+
+<stream name="regionalStatisticsOutput"
+        type="output"
+        filename_template="analysis_members/regionalStatistics.nc"
+        filename_interval="none"
+        clobber_mode="replace_files"
+        packages="regionalStatisticsAMPKG"
+        output_interval="00-00-00_01:00:00" >
+
+	<var name="xtime"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="totalIceArea"/>
+	<var name="totalIceExtent"/>
+	<var name="totalIceVolume"/>
+	<var name="totalSnowVolume"/>
+	<var name="totalKineticEnergy"/>
+	<var name="rmsIceSpeed"/>
+	<var name="averageAlbedo"/>
+	<var name="maximumIceVolume"/>
+	<var name="maximumIceVolumeLocked"/>
+	<var name="maximumIceVolumeNotLocked"/>
+	<var name="maximumIcePressure"/>
+	<var name="maximumIceSpeed"/>
+</stream>
+
+<stream name="conservationCheckOutput"
+        type="output"
+        filename_template="analysis_members/conservationCheck.nc"
+        filename_interval="none"
+        clobber_mode="replace_files"
+        packages="conservationCheckAMPKG"
+        output_interval="00-00-00_01:00:00" >
+
+	<var name="xtime"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="initialEnergy"/>
+	<var name="finalEnergy"/>
+	<var name="energyChange"/>
+	<var name="netEnergyFlux"/>
+	<var name="absoluteEnergyError"/>
+	<var name="relativeEnergyError"/>
+	<var name="initialMass"/>
+	<var name="finalMass"/>
+	<var name="massChange"/>
+	<var name="netMassFlux"/>
+	<var name="absoluteMassError"/>
+	<var name="relativeMassError"/>
+	<var name="initialSalt"/>
+	<var name="finalSalt"/>
+	<var name="saltChange"/>
+	<var name="netSaltFlux"/>
+	<var name="absoluteSaltError"/>
+	<var name="relativeSaltError"/>
+</stream>
+
+
+<stream name="loadBalanceOutput"
+        type="output"
+        filename_template="analysis_members/seaice_loadBalance.nc"
+        filename_interval="none"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="loadBalanceAMPKG"
+        output_interval="00-00-00_01:00:00" >
+
+	<var name="xtime"/>
+	<var name="nCellsProcWithSeaIce"/>
+	<var name="nCellsProc"/>
+</stream>
+
+<stream name="maximumIcePresenceOutput"
+        type="output"
+        filename_template="analysis_members/seaice_maximumIcePresence.$Y.nc"
+        filename_interval="01-00-00_00:00:00"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="maximumIcePresenceAMPKG"
+        output_interval="01-00-00_00:00:00" >
+
+	<stream name="mesh"/>
+	<var name="xtime"/>
+	<var name="maximumIcePresence"/>
+</stream>
+
+<stream name="timeSeriesStatsDailyRestart"
+        type="input;output"
+        filename_template="restarts/restart.AM.timeSeriesStatsDaily.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="output_interval"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsDailyAMPKG"
+        input_interval="initial_only"
+        output_interval="stream:restart:output_interval" >
+
+</stream>
+
+<stream name="timeSeriesStatsDailyOutput"
+        type="output"
+        filename_template="analysis_members/timeSeriesStatsDaily.$Y-$M.nc"
+        filename_interval="00-01-00_00:00:00"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsDailyAMPKG"
+        output_interval="00-00-01_00:00:00" >
+
+</stream>
+
+<stream name="timeSeriesStatsMonthlyRestart"
+        type="input;output"
+        filename_template="restarts/restart.AM.timeSeriesStatsMonthly.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="output_interval"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsMonthlyAMPKG"
+        input_interval="initial_only"
+        output_interval="stream:restart:output_interval" >
+
+</stream>
+
+<stream name="timeSeriesStatsMonthlyOutput"
+        type="output"
+        filename_template="analysis_members/timeSeriesStatsMonthly.$Y-$M.nc"
+        filename_interval="00-01-00_00:00:00"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsMonthlyAMPKG"
+        output_interval="00-01-00_00:00:00" >
+
+	<var name="daysSinceStartOfSim"/>
+	<var name="icePresent"/>
+	<var name="iceAreaCell"/>
+	<var name="iceVolumeCell"/>
+	<var name="snowVolumeCell"/>
+	<var name="iceAreaCategory"/>
+	<var name="iceVolumeCategory"/>
+	<var name="snowVolumeCategory"/>
+	<var name="surfaceTemperatureCell"/>
+	<var name="uVelocityGeo"/>
+	<var name="vVelocityGeo"/>
+	<var name="shortwaveDown"/>
+	<var name="longwaveDown"/>
+	<var name="seaSurfaceTemperature"/>
+	<var name="seaSurfaceSalinity"/>
+	<var name="uOceanVelocityVertexGeo"/>
+	<var name="vOceanVelocityVertexGeo"/>
+	<var name="freezingMeltingPotential"/>
+	<var name="shortwaveScalingFactor"/>
+	<var name="airTemperature"/>
+	<var name="congelation"/>
+	<var name="frazilFormation"/>
+	<var name="snowiceFormation"/>
+	<var name="snowMelt"/>
+	<var name="surfaceIceMelt"/>
+	<var name="basalIceMelt"/>
+	<var name="lateralIceMelt"/>
+	<var name="airStressVertexUGeo"/>
+	<var name="airStressVertexVGeo"/>
+	<var name="icePressure"/>
+	<var name="divergence"/>
+	<var name="shear"/>
+	<var name="principalStress1Var"/>
+	<var name="principalStress2Var"/>
+	<var name="iceVolumeTendencyThermodynamics"/>
+	<var name="iceVolumeTendencyTransport"/>
+	<var name="iceAreaTendencyThermodynamics"/>
+	<var name="iceAreaTendencyTransport"/>
+	<var name="iceAgeTendencyThermodynamics"/>
+	<var name="iceAgeTendencyTransport"/>
+	<var name="iceAgeCell"/>
+	<var name="firstYearIceAreaCell"/>
+	<var name="levelIceAreaCell"/>
+	<var name="levelIceVolumeCell"/>
+	<var name="ridgedIceAreaAverage"/>
+	<var name="ridgedIceVolumeAverage"/>
+	<var name="bulkSalinity"/>
+	<var name="broadbandAlbedo"/>
+	<var name="absorbedShortwaveFluxInitialArea"/>
+	<var name="latentHeatFluxInitialArea"/>
+	<var name="sensibleHeatFluxInitialArea"/>
+	<var name="longwaveUpInitialArea"/>
+	<var name="evaporativeWaterFluxInitialArea"/>
+	<var name="meltPondAreaFinalArea"/>
+	<var name="meltPondDepthFinalArea"/>
+	<var name="meltPondLidThicknessFinalArea"/>
+
+</stream>
+
+<stream name="timeSeriesStatsClimatologyOutput"
+        type="output"
+        filename_template="analysis_members/timeSeriesStatsClimatology.$Y.nc"
+        filename_interval="01-00-00_00:00:00"
+        reference_time="0000-03-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsClimatologyAMPKG"
+        output_interval="00-03-00_00:00:00" >
+
+</stream>
+
+<stream name="timeSeriesStatsClimatologyRestart"
+        type="input;output"
+        filename_template="restarts/restart.AM.timeSeriesStatsClimatology.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="output_interval"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsClimatologyAMPKG"
+        input_interval="initial_only"
+        output_interval="stream:restart:output_interval" >
+
+</stream>
+
+<stream name="timeSeriesStatsCustomOutput"
+        type="output"
+        filename_template="analysis_members/timeSeriesStatsCustom.$Y$M-$D.nc"
+        filename_interval="00-00-07_00:00:00"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsCustomAMPKG"
+        output_interval="00-00-01_00:00:00" >
+
+</stream>
+
+<stream name="timeSeriesStatsCustomRestart"
+        type="input;output"
+        filename_template="restarts/restart.AM.timeSeriesStatsCustom.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="output_interval"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsCustomAMPKG"
+        input_interval="initial_only"
+        output_interval="stream:restart:output_interval" >
+
+</stream>
+
+</streams>

--- a/utils/MPM/particle_initialization/initial_particle_positions.py
+++ b/utils/MPM/particle_initialization/initial_particle_positions.py
@@ -202,6 +202,22 @@ def in_geom(x,
               iceArea = 1.0
               iceVolume = 1.0
 
+   elif (icType == 'cap'):
+
+          lat = asin(z)
+          if(lat > 1.22):
+              in_geom = True
+              iceArea = 1.0
+              iceVolume = 1.0
+
+   elif (icType == 'ring'):
+
+          lat = asin(z)
+          if(lat > 1.0 and lat < 1.25):
+               in_geom = True
+               iceArea = 1.0
+               iceVolume = 1.0
+
    return in_geom, iceArea, iceVolume
 
 #-------------------------------------------------------------------------------

--- a/utils/MPM/particle_initialization/initial_particle_positions.py
+++ b/utils/MPM/particle_initialization/initial_particle_positions.py
@@ -205,7 +205,7 @@ def in_geom(x,
    elif (icType == 'cap'):
 
           lat = asin(z)
-          if(lat > 1.22):
+          if (lat > 1.22):
               in_geom = True
               iceArea = 1.0
               iceVolume = 1.0
@@ -213,7 +213,7 @@ def in_geom(x,
    elif (icType == 'ring'):
 
           lat = asin(z)
-          if(lat > 1.0 and lat < 1.25):
+          if (lat > 1.0 and lat < 1.25):
                in_geom = True
                iceArea = 1.0
                iceVolume = 1.0


### PR DESCRIPTION
(1) advection_time_convergence tests advection of a scalar on a fixed grid but with a sequence of decreasing time steps. 
(2) velocity_advection_test tests advection of a velocity field using mpm using a manufactured solution u=cos(lat), v=0, imposed by prescribing fixed airStressVertex.

Add two options for initial particle configurations - a cap and a ring.

Change the function reconstruction test cases to test the reconstructed velocity field stored in 
uVelocityInitial, vVelocityInitial against the analytical solution.

Concomitant PR: https://github.com/MPAS-Seaice-MPM-Project/MPAS-Seaice-MPM/pull/84
