### PR TITLE
Modify test cases for better testing of MPM Phase III code.

### DIFF
--- a/configurations/standard_physics_mpm/namelist.seaice
+++ b/configurations/standard_physics_mpm/namelist.seaice
@@ -87,7 +87,7 @@
     config_rotate_cartesian_grid = true
     config_include_metric_terms = true
     config_elastic_subcycle_number = 120
-    config_strain_scheme = 'variational'
+    config_strain_scheme = 'mpm'
     config_constitutive_relation_type = 'evp'
     config_stress_divergence_scheme = 'variational'
     config_variational_basis = 'wachspress'

--- a/testcases/MPM/run_testcases.py
+++ b/testcases/MPM/run_testcases.py
@@ -18,7 +18,6 @@ def run_testcases(optional=False):
         "advection_convergence",
         "assembly",
         "column_on_particles",
-        "mpm_tracers",
         "polynya",
         "spherical_operators/interpolation",
         "spherical_operators/reconstruction",

--- a/testcases/MPM/standard_physics/namelist.seaice.default
+++ b/testcases/MPM/standard_physics/namelist.seaice.default
@@ -69,7 +69,7 @@
     config_forcing_cycle_duration = '2-00-00_00:00:00'
     config_forcing_precipitation_units = 'mm_per_sec'
     config_forcing_sst_type = 'ncar'
-    config_forcing_bgc_type = 'ISPOL'
+    config_forcing_bgc_type = 'none'
     config_update_ocean_fluxes = false
     config_frazil_coupling_type = 'external'
     config_include_pond_freshwater_feedback = false
@@ -89,7 +89,7 @@
     config_elastic_subcycle_number = 120
     config_strain_scheme = 'mpm'
     config_constitutive_relation_type = 'evp'
-    config_stress_divergence_scheme = 'variational'
+    config_stress_divergence_scheme = 'mpm'
     config_variational_basis = 'wachspress'
     config_variational_denominator_type = 'original'
     config_wachspress_integration_type = 'dunavant'
@@ -106,7 +106,7 @@
     config_use_special_boundaries_velocity_masks = false
 /
 &advection
-    config_advection_type = 'incremental_remap'
+    config_advection_type = 'mpm'
     config_monotonic = true
     config_conservation_check = false
     config_monotonicity_check = false
@@ -114,7 +114,7 @@
 /
 &mpm
     config_use_mpm_velocity_solver = true
-    config_use_mpm_freeze_melt = false
+    config_use_mpm_freeze_melt = true
     config_use_mpm_polympo = false
     config_mpm_create_particles = true
     config_mpm_particle_init_type = 'number'
@@ -126,7 +126,7 @@
 /
 &column_package
     config_column_physics_type = 'icepack'
-    config_column_element_type = 'cells'
+    config_column_element_type = 'particles'
     config_use_column_shortwave = true
     config_use_column_vertical_thermodynamics = true
     config_use_column_biogeochemistry = false


### PR DESCRIPTION
Change standard physics configuration to use mpm strains.

Change the standard physics test case to use mpm strains, stress divergence, and advection.
    Turn on mpm_freeze_melt. Set column_element_type to partilces.

Remove mpm_tracers from the MPM/runtestcases.py standard testing. (Current form of the test is not useful, but maybe modified in the future.)

See concomitant main code PR: https://github.com/MPAS-Seaice-MPM-Project/MPAS-Seaice-MPM/pull/95