### PR TITLE
Preparation for the elastic-de cohesion model.

### DIFF
--- a/testcases/MPM/spherical_operators/strain/strain_scaling.py
+++ b/testcases/MPM/spherical_operators/strain/strain_scaling.py
@@ -148,11 +148,11 @@ def get_norm_particle(filenameIC, filename, latitudeLimit):
 
     latParticle = fileMPAS.variables["latCellMP"][:]
 
-    strainMP = fileMPAS.variables["strainMP"][:]
+    strainRateMP = fileMPAS.variables["strainRateMP"][:]
 
-    normE11 = L2_norm_particle(strainMP[0,:,0], strainAnalyticalMP[:,0], nParticles, latParticle[0,:], latitudeLimit)
-    normE22 = L2_norm_particle(strainMP[0,:,1], strainAnalyticalMP[:,1], nParticles, latParticle[0,:], latitudeLimit)
-    normE12 = L2_norm_particle(strainMP[0,:,2], strainAnalyticalMP[:,2], nParticles, latParticle[0,:], latitudeLimit)
+    normE11 = L2_norm_particle(strainRateMP[0,:,0], strainAnalyticalMP[:,0], nParticles, latParticle[0,:], latitudeLimit)
+    normE22 = L2_norm_particle(strainRateMP[0,:,1], strainAnalyticalMP[:,1], nParticles, latParticle[0,:], latitudeLimit)
+    normE12 = L2_norm_particle(strainRateMP[0,:,2], strainAnalyticalMP[:,2], nParticles, latParticle[0,:], latitudeLimit)
 
     fileMPAS.close()
 
@@ -267,7 +267,7 @@ def strain_scaling():
                 elif (strain == "strain12"):
                     y.append(normE12)
 
-            axes[iStrain].loglog(x,y, marker='o', color=lineColours[iPlot], ls="solid", markersize=5.0, label="strainMP_%s" %(method))
+            axes[iStrain].loglog(x,y, marker='o', color=lineColours[iPlot], ls="solid", markersize=5.0, label="strainRateMP_%s" %(method))
 
             iPlot = iPlot + 1
 

--- a/testcases/MPM/spherical_operators/strain/streams.seaice.strain
+++ b/testcases/MPM/spherical_operators/strain/streams.seaice.strain
@@ -50,7 +50,7 @@
    <var name="latCellMP"/>
    <var name="lonCellMP"/>
    <var name="uvVelMP"/>
-   <var name="strainMP"/>
+   <var name="strainRateMP"/>
    <var name="stressMP"/>
 </stream>
 

--- a/testcases/MPM/spherical_operators/strain_stress_divergence/streams.seaice.strain_stress_divergence
+++ b/testcases/MPM/spherical_operators/strain_stress_divergence/streams.seaice.strain_stress_divergence
@@ -74,7 +74,7 @@
         <var name="procIDParticle"/>
         <var name="posnMP"/>
         <var name="iceAreaCellMP"/>
-        <var name="strainMP"/>
+        <var name="strainRateMP"/>
 </stream>
 
 


### PR DESCRIPTION
Change strainMP to strainRateMP in preparation for running the elastic-decohesive model.

See concomitant code changes:
 https://github.com/MPAS-Seaice-MPM-Project/MPAS-Seaice_standalone_framework/pull/51