### PR TITLE
Remove crack tracking

### DIFF
--- a/configurations/standard_physics_mpm_decoh/README
+++ b/configurations/standard_physics_mpm_decoh/README
@@ -1,0 +1,1 @@
+standard physics configuration for MPM

--- a/configurations/standard_physics_mpm_decoh/namelist.seaice
+++ b/configurations/standard_physics_mpm_decoh/namelist.seaice
@@ -1,5 +1,5 @@
 &seaice_model
-    config_dt = 900.0
+    config_dt = 3600.0
     config_calendar_type = 'noleap'
     config_start_time = '2000-01-01_00:00:00'
     config_stop_time = 'none'
@@ -41,35 +41,35 @@
 /
 &initialize
     config_earth_radius = 6371229.0
-    config_initial_condition_type = 'none'
+    config_initial_condition_type = 'cice_default'
     config_initial_ice_area = 1.0
     config_initial_ice_volume = 1.0
     config_initial_snow_volume = 0.0
     config_initial_latitude_north = 70.0
     config_initial_latitude_south = -60.0
-    config_initial_velocity_type = 'none'
+    config_initial_velocity_type = 'uniform'
     config_initial_uvelocity = 0.0
     config_initial_vvelocity = 0.0
-    config_calculate_coriolis = false
+    config_calculate_coriolis = true
 /
 &use_sections
     config_use_dynamics = true
     config_use_velocity_solver = true
     config_use_mpm = true
     config_use_advection = true
-    config_use_forcing = false
+    config_use_forcing = true
     config_use_column_physics = true
-    config_use_mpm_icebergs = false
     config_use_prescribed_ice = false
     config_use_prescribed_ice_forcing = false
+    config_use_mpm_icebergs = false
 /
 &forcing
-    config_atmospheric_forcing_type = 'none'
+    config_atmospheric_forcing_type = 'CORE'
     config_forcing_start_time = '2000-01-01_00:00:00'
     config_forcing_cycle_start = '2000-01-01_00:00:00'
     config_forcing_cycle_duration = '2-00-00_00:00:00'
     config_forcing_precipitation_units = 'mm_per_sec'
-    config_forcing_sst_type = 'none'
+    config_forcing_sst_type = 'ncar'
     config_forcing_bgc_type = 'none'
     config_update_ocean_fluxes = false
     config_frazil_coupling_type = 'external'
@@ -84,10 +84,9 @@
     config_limit_air_temperatures = true
 /
 &velocity_solver
-    config_two_pass_mpm_strain = false
     config_dynamics_subcycle_number = 1
-    config_rotate_cartesian_grid = false
-    config_include_metric_terms = false
+    config_rotate_cartesian_grid = true
+    config_include_metric_terms = true
     config_elastic_subcycle_number = 120
     config_strain_scheme = 'mpm'
     config_constitutive_relation_type = 'decohesion'
@@ -118,7 +117,7 @@
     config_use_mpm_velocity_solver = true
     config_use_mpm_freeze_melt = false
     config_use_mpm_polympo = false
-    config_mpm_create_particles = false
+    config_mpm_create_particles = true
     config_mpm_particle_init_type = 'number'
     config_mpm_particle_posn_init_type = 'xyprojection'
     config_mpm_particle_init_number = 9
@@ -129,19 +128,19 @@
 &elastic_decohesion_model
     config_youngs_modulus = 1.e6
     config_poissons_ratio = 0.36
-    config_tensile_strength = 1200.
-    config_compressive_strength = 6000.
-    config_shear_strength = 720.
+    config_tensile_strength = 25.e3
+    config_compressive_strength = 125.e3
+    config_shear_strength = 75.e3
     config_shear_magnification_factor = 4.0
-    config_jump_scale_factor = 25.0
+    config_jump_scale_factor = 4000.0
 /
 &column_package
     config_column_physics_type = 'icepack'
     config_column_element_type = 'particles'
-    config_use_column_shortwave = false
-    config_use_column_vertical_thermodynamics = false
+    config_use_column_shortwave = true
+    config_use_column_vertical_thermodynamics = true
     config_use_column_biogeochemistry = false
-    config_use_column_itd_thermodynamics = false
+    config_use_column_itd_thermodynamics = true
     config_use_column_ridging = true
     config_use_column_snow_tracers = false
 /
@@ -475,7 +474,7 @@
     config_AM_pondDiagnostics_write_on_startup = false
 /
 &AM_unitConversion
-    config_AM_unitConversion_enable = false
+    config_AM_unitConversion_enable = true
     config_AM_unitConversion_compute_interval = 'dt'
     config_AM_unitConversion_output_stream = 'none'
     config_AM_unitConversion_compute_on_startup = false

--- a/configurations/standard_physics_mpm_decoh/streams.seaice
+++ b/configurations/standard_physics_mpm_decoh/streams.seaice
@@ -29,8 +29,6 @@
 	<var name="snowVolumeCell"/>
 	<var name="uVelocity"/>
 	<var name="vVelocity"/>
-   <var name="deluDyn"/>
-   <var name="delvDyn"/>
 </stream>
 
 <stream name="particlesOut"
@@ -42,17 +40,12 @@
 
    <var name="statusMP"/>
    <var name="iCellMP"/>
-   <var name="cellIDCreationMP"/>
-   <var name="creationIndexMP"/>
-   <var name="indexToCellIDMP"/>
-   <var name="procIDParticle"/>
-   <var name="posnMP"/>
-   <var name="iceAreaCellMP"/>
-   <var name="iceVolumeCellMP"/>
-   <var name="uvVelMP"/>
-   <var name="decohesionOpeningMP"/>
+        <var name="cellIDCreationMP"/>
+        <var name="creationIndexMP"/>
+        <var name="indexToCellIDMP"/>
+        <var name="procIDParticle"/>
+        <var name="posnMP"/>
 </stream>
-
 
 <immutable_stream name="LYqSixHourlyForcing"
                   type="input"

--- a/testcases/MPM/decohesion/bar_with_tension_or_shear/plot_decohesion.py
+++ b/testcases/MPM/decohesion/bar_with_tension_or_shear/plot_decohesion.py
@@ -44,8 +44,6 @@ def plot_decohesion(gridFilename):
         nParticles = len(filein.dimensions["nParticles"])
         posnMP = filein.variables["posnMP"][:,:,:]
         decohesionOpeningMP = filein.variables["decohesionOpeningMP"][:,:,:]
-        decohesionCrackEndPoints = filein.variables["decohesionCrackEndPoints"][:,:,:]
-        decohesionCrackEdgeIndex = filein.variables["decohesionCrackEdgeIndex"][:,:,:]
         filein.close()
 
         # plot decohesionOpeningMP at posnMP
@@ -60,42 +58,6 @@ def plot_decohesion(gridFilename):
         plt.colorbar(scatter)
         plt.tight_layout()
         filenameOut = "plots/decohesion_%i.png"%(iTime)
-        plt.savefig(filenameOut,dpi=600)
-        plt.close()
-
-        # plot the mesh and cracks
-        patchesCell = []
-        for iCell in range(0,nCells):
-           vertices = []
-           for iVertexOnCell in range(0,nEdgesOnCell[iCell]):
-               iVertex = verticesOnCell[iCell,iVertexOnCell]
-               vertices.append((xVertex[iVertex],yVertex[iVertex]))
-           patchesCell.append(Polygon(vertices,closed=True, edgecolor="teal", fill=False, linewidth=0.1))
-
-        pc = PatchCollection(patchesCell, match_original=True)
-
-        crackLines = []
-        for iCell in range(0, nCells):
-           crackIndex = decohesionCrackEdgeIndex[0,iCell,:] - 1
-           if (crackIndex[0] >= 0 and crackIndex[1] >=0):
-              iEdges = edgesOnCell[iCell, crackIndex]
-              crackLines.append([(decohesionCrackEndPoints[0,iEdges[0],0],decohesionCrackEndPoints[0,iEdges[0],1]),
-                                 (decohesionCrackEndPoints[0,iEdges[1],0],decohesionCrackEndPoints[0,iEdges[1],1])])
-
-        lc = LineCollection(crackLines)
-
-        fig, axis = plt.subplots(figsize=(10,10))
-        axis.add_collection(pc)
-        axis.add_collection(lc)
-        axis.scatter(decohesionCrackEndPoints[0,:,0], decohesionCrackEndPoints[0,:,1], marker='o')
-        axis.set_xlim((xmin-0.05*lxy,xmax+0.05*lxy))
-        axis.set_ylim((ymin-0.05*lxy,ymax+0.05*lxy))
-        axis.set_aspect('equal')
-        axis.set_xlabel("x")
-        axis.set_ylabel("y")
-
-        plt.tight_layout()
-        filenameOut = "plots/cracks_%i.png"%(iTime)
         plt.savefig(filenameOut,dpi=600)
         plt.close()
 

--- a/testcases/MPM/decohesion/bar_with_tension_or_shear/streams.seaice
+++ b/testcases/MPM/decohesion/bar_with_tension_or_shear/streams.seaice
@@ -71,8 +71,6 @@
         <var name="procIDParticle"/>
         <var name="posnMP"/>
         <var name="decohesionOpeningMP"/>
-        <var name="decohesionCrackEndPoints"/>
-        <var name="decohesionCrackEdgeIndex"/>
         <var name="stressMP"/>
         <var name="uvVelMP"/>
 </stream>

--- a/testcases/MPM/decohesion/bbm_compression/add_initial_area_volume_categories.py
+++ b/testcases/MPM/decohesion/bbm_compression/add_initial_area_volume_categories.py
@@ -1,0 +1,98 @@
+import argparse
+import numpy as np
+import netCDF4 as nc
+import os
+
+#--------------------------------------------------------------------
+
+def add_initial_area_volume_categories():
+
+   icFilename = 'particles.nc'
+   if (not os.path.isfile(icFilename)):
+      raise Exception("Mising particle file: "+icFilenam)
+
+   cmd = "mv particles.nc particle_sourcefile.nc"
+   os.system(cmd)
+
+   # make a new netcdf file with proper category variables
+   ds_orig = nc.Dataset('particle_sourcefile.nc', 'r')
+   ds_new = nc.Dataset(icFilename, 'w', format='NETCDF3_CLASSIC')
+
+   # create new dimension
+   nCategories = 5
+   ds_new.createDimension('nCategories', nCategories)
+   # copy other dimensions
+   for name, dimension in ds_orig.dimensions.items():
+      if name != 'nCategories':
+          ds_new.createDimension(name, dimension.size if not dimension.isunlimited() else None)
+
+   # copy other (non-category) variables from the old file to the new file
+   exclude_from_copy = ["iceAreaCategoryMP", "iceVolumeCategoryMP", "iceAreaCellMP", "iceVolumeCellMP"]
+   for name, variable in ds_orig.variables.items():
+      if (name not in exclude_from_copy):
+         var = ds_new.createVariable(name, variable.dtype, variable.dimensions)
+         var[:] = variable[:]
+         for attr_name, attr_value in variable.__dict__.items():
+            if attr_name not in ['_FillValue']:
+               setattr(var, attr_name, attr_value)
+
+   # copy attributes
+   for attr_name, attr_value in ds_orig.__dict__.items():
+      setattr(ds_new, attr_name, attr_value)
+
+   # create the category variables and data
+   nParticles = len(ds_orig.dimensions["nParticles"])
+   iceAreaCategoryMP =   np.zeros((nParticles,nCategories))
+   iceVolumeCategoryMP = np.zeros((nParticles,nCategories))
+
+   iceAreaCellMP =   np.zeros(nParticles)
+   iceVolumeCellMP = np.zeros(nParticles)
+
+   categoryThicknessLimits = \
+               [0, 0.6, 1.4, 2.4, 3.6, 100000000]
+
+   iceAreaCategoryInit = np.zeros(nCategories)
+   iceAreaCategoryInit[0] = 0.05
+   iceAreaCategoryInit[1] = 0.1
+   iceAreaCategoryInit[2] = 0.3
+   iceAreaCategoryInit[3] = 0.35
+   iceAreaCategoryInit[4] = 0.2
+
+   iceThicknesses = np.zeros(nCategories)
+   for iCategory in range(0,nCategories-1):
+       iceThicknesses[iCategory] = 0.5 * (categoryThicknessLimits[iCategory] +
+                                          categoryThicknessLimits[iCategory+1])
+       iceThicknesses[nCategories-1] = categoryThicknessLimits[nCategories-1] + 1.0
+
+   for iParticle in range(0, nParticles):
+       for iCategory in range(0, nCategories):
+          iceAreaCategoryMP[iParticle,iCategory] = iceAreaCategoryInit[iCategory]
+          iceAreaCellMP[iParticle] = np.sum(iceAreaCategoryMP[iParticle,:])
+
+       for iCategory in range(0, nCategories):
+           iceVolumeCategoryMP[iParticle,iCategory] = iceThicknesses[iCategory] \
+                                                      * iceAreaCategoryMP[iParticle,iCategory]
+           iceVolumeCellMP[iParticle] = np.sum(iceVolumeCategoryMP[iParticle,:])
+
+   # add category data to new file
+   var = ds_new.createVariable("iceAreaCategoryMP", "d", dimensions=["nParticles","nCategories","ONE"])
+   var[:,:,0] = iceAreaCategoryMP[:,:]
+
+   var = ds_new.createVariable("iceVolumeCategoryMP", "d", dimensions=["nParticles","nCategories","ONE"])
+   var[:,:,0] = iceVolumeCategoryMP[:,:]
+
+   var = ds_new.createVariable("iceAreaCellMP", "d", dimensions=["nParticles"])
+   var[:] = iceAreaCellMP[:]
+
+   var = ds_new.createVariable("iceVolumeCellMP", "d", dimensions=["nParticles"])
+   var[:] = iceVolumeCellMP[:]
+
+   ds_new.close()
+   ds_orig.close()
+   os.remove('particle_sourcefile.nc')
+
+#--------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    add_initial_area_volume_categories()

--- a/testcases/MPM/decohesion/bbm_compression/create_ics.py
+++ b/testcases/MPM/decohesion/bbm_compression/create_ics.py
@@ -1,0 +1,54 @@
+from netCDF4 import Dataset
+import numpy as np
+import argparse
+
+#-------------------------------------------------------------------------------
+
+def create_ics(gridFilename):
+
+    uAir = -5.0
+    vAir =  0.0
+
+    # grid data
+    fileGrid = Dataset(gridFilename,"r")
+
+    nCells = len(fileGrid.dimensions["nCells"])
+
+    xCell = fileGrid.variables["xCell"][:]
+    yCell = fileGrid.variables["yCell"][:]
+
+    fileGrid.close()
+
+    uAirVelocity = np.zeros(nCells)
+    vAirVelocity = np.zeros(nCells)
+
+    for iCell in range(0, nCells):
+
+        x = xCell[iCell]
+        y = yCell[iCell]
+        uAirVelocity[iCell] = uAir
+        #vAirVelocity[iCell] = vAir
+
+    fileOut = Dataset("ic.nc", "w", format="NETCDF3_CLASSIC")
+
+    fileOut.createDimension("nCells", nCells)
+
+    var = fileOut.createVariable("uAirVelocity", "d", dimensions=["nCells"])
+    var[:] = uAirVelocity
+
+    var = fileOut.createVariable("vAirVelocity", "d", dimensions=["nCells"])
+    var[:] = vAirVelocity
+
+    fileOut.close()
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-g', dest='gridFilename', required=True)
+
+    args = parser.parse_args()
+
+    create_ics(args.gridFilename)

--- a/testcases/MPM/decohesion/bbm_compression/namelist.seaice
+++ b/testcases/MPM/decohesion/bbm_compression/namelist.seaice
@@ -1,5 +1,5 @@
 &seaice_model
-    config_dt = 900.0
+    config_dt = 900.
     config_calendar_type = 'noleap'
     config_start_time = '2000-01-01_00:00:00'
     config_stop_time = 'none'
@@ -127,13 +127,13 @@
     config_mpm_polympo_init_test = false
 /
 &elastic_decohesion_model
-    config_youngs_modulus = 1.e6
-    config_poissons_ratio = 0.36
-    config_tensile_strength = 1200.
-    config_compressive_strength = 6000.
-    config_shear_strength = 720.
+    config_youngs_modulus = 1.0e6
+    config_poissons_ratio = 0.33
+    config_tensile_strength = 3000.0
+    config_compressive_strength = 10000.0
+    config_shear_strength = 2000.0
     config_shear_magnification_factor = 4.0
-    config_jump_scale_factor = 25.0
+    config_jump_scale_factor = 100.0
 /
 &column_package
     config_column_physics_type = 'icepack'

--- a/testcases/MPM/decohesion/bbm_compression/plot_results.py
+++ b/testcases/MPM/decohesion/bbm_compression/plot_results.py
@@ -1,0 +1,112 @@
+from netCDF4 import Dataset
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.patches import Polygon
+from matplotlib.collections import PatchCollection
+from matplotlib.collections import LineCollection
+import argparse
+import glob
+import os
+
+#-------------------------------------------------------------------------------
+
+def plot_results(gridFilename):
+
+    filein = Dataset(gridFilename,"r")
+    nCells = len(filein.dimensions["nCells"])
+    nEdges = len(filein.dimensions["nEdges"])
+    nEdgesOnCell = filein.variables["nEdgesOnCell"][:]
+    verticesOnCell = filein.variables["verticesOnCell"][:]-1
+    edgesOnCell = filein.variables["edgesOnCell"][:]-1
+    xVertex = filein.variables["xVertex"][:]
+    yVertex = filein.variables["yVertex"][:]
+    filein.close()
+
+    xmin = np.amin(xVertex)
+    xmax = np.amax(xVertex)
+    ymin = np.amin(yVertex)
+    ymax = np.amax(yVertex)
+    lx = xmax - xmin
+    ly = ymax - ymin
+    lxy = max(lx,ly)
+
+    filenames = sorted(glob.glob("./output/particles_output.*"))
+    iTime = -1
+    filein = Dataset(filenames[iTime],"r")
+    nParticles = len(filein.dimensions["nParticles"])
+    posnMP = filein.variables["posnMP"][:,:,:]
+    uvVelMP = filein.variables["uvVelMP"][:,:,:]
+    decohesionOpeningMP = filein.variables["decohesionOpeningMP"][:,:,:]
+    filein.close()
+
+    # plot decohesionOpeningMP at posnMP
+    fig, axes = plt.subplots(2,2)
+    color = decohesionOpeningMP[0,:,0]
+    axes[0,0].set_xlim(xmin,xmax)
+    axes[0,0].set_ylim(ymin,ymax)
+    M = axes[0,0].transData.get_matrix()
+    xscale = M[0,0]
+    yscale = M[1,1]
+    size = xscale * yscale * lx * ly / nCells / 36
+    scatter = axes[0,0].scatter(posnMP[0,:,0], posnMP[0,:,1], c = color, s = size)
+    axes[0,0].set_xlabel("x")
+    axes[0,0].set_ylabel("y")
+    axes[0,0].set_title("normal opening")
+    scatter.set_clim(vmin=0, vmax=10)
+    fig.colorbar(scatter)
+
+    color = decohesionOpeningMP[0,:,1]
+    axes[0,1].set_xlim(xmin,xmax)
+    axes[0,1].set_ylim(ymin,ymax)
+    M = axes[0,1].transData.get_matrix()
+    xscale = M[0,0]
+    yscale = M[1,1]
+    size = xscale * yscale * lx * ly / nCells / 36
+    scatter = axes[0,1].scatter(posnMP[0,:,0], posnMP[0,:,1], c = color, s = size)
+    axes[0,1].set_xlabel("x")
+    axes[0,1].set_ylabel("y")
+    axes[0,1].set_title("tangential opening")
+    scatter.set_clim(vmin=-10, vmax=10)
+    fig.colorbar(scatter)
+
+    color = abs(decohesionOpeningMP[0,:,0]) + abs(decohesionOpeningMP[0,:,1])
+    axes[1,0].set_xlim(xmin,xmax)
+    axes[1,0].set_ylim(ymin,ymax)
+    M = axes[1,0].transData.get_matrix()
+    xscale = M[0,0]
+    yscale = M[1,1]
+    size = xscale * yscale * lx * ly / nCells / 36
+    scatter = axes[1,0].scatter(posnMP[0,:,0], posnMP[0,:,1], c = color, s = size)
+    axes[1,0].set_xlabel("x")
+    axes[1,0].set_ylabel("y")
+    axes[1,0].set_title("combined (1-norm) opening")
+    scatter.set_clim(vmin=0, vmax=10)
+    fig.colorbar(scatter)
+
+    color = uvVelMP[0,:,0]
+    axes[1,1].set_xlim(xmin,xmax)
+    axes[1,1].set_ylim(ymin,ymax)
+    M = axes[1,1].transData.get_matrix()
+    xscale = M[0,0]
+    yscale = M[1,1]
+    size = xscale * yscale * lx * ly / nCells / 36
+    scatter = axes[1,1].scatter(posnMP[0,:,0], posnMP[0,:,1], c = color, s = size)
+    axes[1,1].set_xlabel("x")
+    axes[1,1].set_ylabel("y")
+    axes[1,1].set_title("u-Velocity")
+    scatter.set_clim(vmin=-0.05, vmax=1.e-5)
+    fig.colorbar(scatter)
+
+    plt.tight_layout()
+    filenameOut = "decohesion.png"
+    plt.savefig(filenameOut,dpi=600)
+    plt.close()
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-g', dest='gridFilename')
+    args = parser.parse_args()
+    plot_results(args.gridFilename)

--- a/testcases/MPM/decohesion/bbm_compression/run_model.py
+++ b/testcases/MPM/decohesion/bbm_compression/run_model.py
@@ -1,0 +1,30 @@
+import os, sys
+
+sys.path.append("../../../../utils/testcases")
+from execute_model import execute_model
+
+#-------------------------------------------------------------------------------
+
+def run_model():
+
+    MPAS_SEAICE_EXECUTABLE = os.environ.get('MPAS_SEAICE_EXECUTABLE')
+    if (MPAS_SEAICE_EXECUTABLE is None):
+        MPAS_SEAICE_EXECUTABLE = "../../../../../MPAS-Seaice-MPM/components/mpas-seaice/seaice_model"
+        print("Using executable in standard location: %s" %(MPAS_SEAICE_EXECUTABLE))
+
+    if (os.path.isdir("output")):
+        cmd = "rm -rf output"
+        os.system(cmd)
+    os.mkdir("output")
+
+    nProcs = 1
+    logFile = None
+    execute_model(MPAS_SEAICE_EXECUTABLE,
+                  nProcs,
+                  logFile)
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    run_model()

--- a/testcases/MPM/decohesion/bbm_compression/run_testcase.py
+++ b/testcases/MPM/decohesion/bbm_compression/run_testcase.py
@@ -1,0 +1,118 @@
+from run_model import run_model
+from create_ics import create_ics
+from add_initial_area_volume_categories import add_initial_area_volume_categories
+from plot_results import plot_results
+
+import sys, os
+
+sys.path.append("../../../../utils/MPM/particle_initialization/")
+from initial_particle_positions import initial_particle_positions
+
+sys.path.append("../../../../utils/testcases")
+from create_square_hex_mesh import create_square_hex_mesh
+from create_square_quad_mesh import create_square_quad_mesh
+from plot_mesh import plot_mesh
+
+import argparse
+
+#-------------------------------------------------------------------------------
+
+def run_testcase(meshtype, logFilename=None):
+
+    if (logFilename is not None):
+        logFile = open(logFilename,"a")
+        logFile.write("\nDecohesion test case\n")
+        logFile.write(  "===================\n")
+        logFile.flush()
+    else:
+        logFile = None
+
+    print("Create grid")
+    print("=================")
+    if (meshtype == 'hex'):
+        lx = 1040000.0
+        ly = 1040000.0
+        x0 = 0.0
+        y0 = 0.0
+        dc = 10400.0
+        gridFilename = create_square_hex_mesh(dc,
+                                          lx, ly,
+                                          x0, y0)
+    elif (meshtype == 'quad'):
+        lx = 1040000.0
+        ly = 1040000.0
+        x0 = 0.0
+        y0 = 0.0
+        nx = 104
+        ny = 104
+        gridFilename = create_square_quad_mesh(nx, ny,
+                                           lx, ly,
+                                           x0, y0)
+
+    plot_mesh(gridFilename)
+
+    print("Sym link grid...")
+    if (os.path.isfile("grid.nc")):
+        os.system("rm grid.nc")
+    os.symlink(gridFilename,"grid.nc")
+
+    print("Create ICs...")
+    print("=================")
+    create_ics(gridFilename)
+
+    print("Create particles...")
+    print("=================")
+    if (meshtype == 'hex'):
+       particleInitType = "number"
+       particleInitNumber = "9"
+       particlePositionInitType = "onePerEdge"
+       particleGeometry = "BBMsquare"
+       sphereRadius = 1.0
+       initial_particle_positions(gridFilename,
+                                "particles.nc",
+                                particleInitType,
+                                particleInitNumber,
+                                particlePositionInitType,
+                                particleGeometry,
+                                sphereRadius)
+    elif (meshtype == 'quad'):
+       particleInitType = "number"
+       particleInitNumber = "4"
+       particlePositionInitType = "even"
+       particleGeometry = "BBMsquare"
+       sphereRadius = 1.0
+       initial_particle_positions(gridFilename,
+                                "particles.nc",
+                                particleInitType,
+                                particleInitNumber,
+                                particlePositionInitType,
+                                particleGeometry,
+                                sphereRadius)
+
+    print("Adding ice categories...")
+    print("=================")
+    add_initial_area_volume_categories()
+
+    print("Run model...")
+    print("=================")
+    run_model()
+
+    print("Plot results...")
+    print("=================")
+    plot_results(gridFilename)
+
+    if (logFile is not None):
+        logFile.close()
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-m', dest="meshtype", choices=["quad","hex"], default="hex")
+    parser.add_argument('-l', dest='logFilename')
+
+    args = parser.parse_args()
+
+    run_testcase(args.meshtype, args.logFilename)

--- a/testcases/MPM/decohesion/bbm_compression/streams.seaice
+++ b/testcases/MPM/decohesion/bbm_compression/streams.seaice
@@ -9,6 +9,30 @@
                   filename_interval="none"
                   input_interval="initial_only" />
 
+<stream name="initialConditions"
+        type="input"
+        filename_template="ic.nc"
+        filename_interval="none"
+        input_interval="initial_only">
+
+   <var name="iceAreaCell"/>
+   <var name="iceVolumeCell"/>
+   <var name="iceAreaCategory"/>
+   <var name="iceVolumeCategory"/>
+   <var name="fVertex"/>
+   <var name="uAirVelocity"/>
+   <var name="vAirVelocity"/>
+   <var name="airStressVertexU"/>
+   <var name="airStressVertexV"/>
+</stream>
+
+
+<immutable_stream name="particleInput"
+                  type="input"
+                  filename_template="particles.nc"
+                  filename_interval="none"
+                  input_interval="initial_only" />
+
 <immutable_stream name="restart"
                   type="input;output"
                   filename_template="restarts/restart.$Y-$M-$D_$h.$m.$s.nc"
@@ -21,7 +45,7 @@
         filename_template="output/output.$Y.nc"
         filename_interval="01-00-00_00:00:00"
         clobber_mode="replace_files"
-        output_interval="00-00-01_00:00:00" >
+        output_interval="00-00-00_01:00:00" >
 	<var name="xtime"/>
 	<var name="daysSinceStartOfSim"/>
 	<var name="iceAreaCell"/>
@@ -38,21 +62,21 @@
         filename_template="output/particles_output.$Y-$M-$D_$h.$m.$s.nc"
         filename_interval="00-00-00_00:00:01"
         clobber_mode="replace_files"
-        output_interval="00-00-01_00:00:00" >
-
-   <var name="statusMP"/>
-   <var name="iCellMP"/>
-   <var name="cellIDCreationMP"/>
-   <var name="creationIndexMP"/>
-   <var name="indexToCellIDMP"/>
-   <var name="procIDParticle"/>
-   <var name="posnMP"/>
-   <var name="iceAreaCellMP"/>
-   <var name="iceVolumeCellMP"/>
-   <var name="uvVelMP"/>
-   <var name="decohesionOpeningMP"/>
+        output_interval="00-00-00_01:00:00" >
+        <var name="statusMP"/>
+        <var name="iCellMP"/>
+        <var name="cellIDCreationMP"/>
+        <var name="creationIndexMP"/>
+        <var name="indexToCellIDMP"/>
+        <var name="procIDParticle"/>
+        <var name="posnMP"/>
+        <var name="iceAreaCellMP"/>
+        <var name="iceVolumeCellMP"/>
+        <var name="decohesionOpeningMP"/>
+        <var name="decohesionStrainMP"/>
+        <var name="stressMP"/>
+        <var name="uvVelMP"/>
 </stream>
-
 
 <immutable_stream name="LYqSixHourlyForcing"
                   type="input"
@@ -167,7 +191,6 @@
 	<var name="absoluteSaltError"/>
 	<var name="relativeSaltError"/>
 </stream>
-
 
 <stream name="loadBalanceOutput"
         type="output"

--- a/testcases/MPM/decohesion/compression/plot_results.py
+++ b/testcases/MPM/decohesion/compression/plot_results.py
@@ -37,8 +37,6 @@ def plot_results(gridFilename):
     posnMP = filein.variables["posnMP"][:,:,:]
     uvVelMP = filein.variables["uvVelMP"][:,:,:]
     decohesionOpeningMP = filein.variables["decohesionOpeningMP"][:,:,:]
-    decohesionCrackEndPoints = filein.variables["decohesionCrackEndPoints"][:,:,:]
-    decohesionCrackEdgeIndex = filein.variables["decohesionCrackEdgeIndex"][:,:,:]
     filein.close()
 
     # plot decohesionOpeningMP at posnMP
@@ -101,42 +99,6 @@ def plot_results(gridFilename):
 
     plt.tight_layout()
     filenameOut = "decohesion.png"
-    plt.savefig(filenameOut,dpi=600)
-    plt.close()
-
-    # plot the mesh and cracks
-    patchesCell = []
-    for iCell in range(0,nCells):
-       vertices = []
-       for iVertexOnCell in range(0,nEdgesOnCell[iCell]):
-           iVertex = verticesOnCell[iCell,iVertexOnCell]
-           vertices.append((xVertex[iVertex],yVertex[iVertex]))
-       patchesCell.append(Polygon(vertices,closed=True, edgecolor="teal", fill=False, linewidth=0.1))
-
-    pc = PatchCollection(patchesCell, match_original=True)
-
-    crackLines = []
-    for iCell in range(0, nCells):
-       crackIndex = decohesionCrackEdgeIndex[0,iCell,:] - 1
-       if (crackIndex[0] >= 0 and crackIndex[1] >=0):
-          iEdges = edgesOnCell[iCell, crackIndex]
-          crackLines.append([(decohesionCrackEndPoints[0,iEdges[0],0],decohesionCrackEndPoints[0,iEdges[0],1]),
-                             (decohesionCrackEndPoints[0,iEdges[1],0],decohesionCrackEndPoints[0,iEdges[1],1])])
-
-    lc = LineCollection(crackLines)
-
-    fig, axis = plt.subplots(figsize=(10,10))
-    axis.add_collection(pc)
-    axis.add_collection(lc)
-    axis.scatter(decohesionCrackEndPoints[0,:,0], decohesionCrackEndPoints[0,:,1], marker='o')
-    axis.set_xlim((xmin-0.05*lxy,xmax+0.05*lxy))
-    axis.set_ylim((ymin-0.05*lxy,ymax+0.05*lxy))
-    axis.set_aspect('equal')
-    axis.set_xlabel("x")
-    axis.set_ylabel("y")
-
-    plt.tight_layout()
-    filenameOut = "cracks.png"
     plt.savefig(filenameOut,dpi=600)
     plt.close()
 

--- a/testcases/MPM/decohesion/compression/streams.seaice
+++ b/testcases/MPM/decohesion/compression/streams.seaice
@@ -72,8 +72,6 @@
         <var name="posnMP"/>
         <var name="decohesionOpeningMP"/>
         <var name="decohesionStrainMP"/>
-        <var name="decohesionCrackEndPoints"/>
-        <var name="decohesionCrackEdgeIndex"/>
         <var name="stressMP"/>
         <var name="uvVelMP"/>
 </stream>

--- a/testcases/MPM/one_dimensional_ridging/namelist.seaice.mpm
+++ b/testcases/MPM/one_dimensional_ridging/namelist.seaice.mpm
@@ -86,7 +86,7 @@
     config_include_metric_terms = false
     config_elastic_subcycle_number = 1200
     config_strain_scheme = 'mpm'
-    config_constitutive_relation_type = 'evp'
+    config_constitutive_relation_type = 'decohesion'
     config_stress_divergence_scheme = 'mpm'
     config_variational_basis = 'wachspress'
     config_variational_denominator_type = 'alternate'
@@ -126,11 +126,11 @@
 &elastic_decohesion_model
     config_youngs_modulus = 1.e6
     config_poissons_ratio = 0.3
-    config_tensile_strength = 25.e3
-    config_compressive_strength = 125.e3
-    config_shear_strength = 75.e3
+    config_tensile_strength = 1200.0
+    config_compressive_strength = 6000.0
+    config_shear_strength = 720.0
     config_shear_magnification_factor = 4.0
-    config_jump_scale_factor = 4000.0
+    config_jump_scale_factor = 100.0
 /
 &column_package
     config_column_physics_type = 'icepack'

--- a/testcases/MPM/one_dimensional_ridging/streams.seaice.mpm
+++ b/testcases/MPM/one_dimensional_ridging/streams.seaice.mpm
@@ -64,8 +64,6 @@
         <var name="uvVelMP"/>
         <var name="stressMP"/>
         <var name="decohesionOpeningMP"/>
-        <var name="decohesionCrackEndPoints"/>
-        <var name="decohesionCrackEdgeIndex"/>
         <var name="iceAreaCellMP"/>
         <var name="iceVolumeCellMP"/>
         <var name="snowVolumeCellMP"/>

--- a/testcases/MPM/ridging_island/streams.seaice.mpm
+++ b/testcases/MPM/ridging_island/streams.seaice.mpm
@@ -62,6 +62,9 @@
         <var name="indexToCellIDMP"/>
         <var name="procIDParticle"/>
         <var name="posnMP"/>
+        <var name="uvVelMP"/>
+        <var name="decohesionOpeningMP"/>
+        <var name="decohesionNormalMP"/>
         <var name="iceAreaCellMP"/>
         <var name="iceVolumeCellMP"/>
         <var name="snowVolumeCellMP"/>

--- a/testing/testsuites/testsuite.standard.mpm.decoh.xml
+++ b/testing/testsuites/testsuite.standard.mpm.decoh.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="standard">
+	<configuration name="standard_physics_mpm_decoh">
+		<domain name="domain_QU120km">
+			<test name="regression"/>
+			<test name="parallelism"/>
+	 		<test name="restartability"/>
+		</domain>
+	</configuration>
+</testsuite>

--- a/utils/MPM/particle_initialization/initial_particle_positions.py
+++ b/utils/MPM/particle_initialization/initial_particle_positions.py
@@ -231,6 +231,12 @@ def in_geom(x,
             iceArea = 1.0
             iceVolume = 1.0
 
+    elif (geomType == 'BBMsquare'):
+        if (x < 1000000 and x > 0 and y < 1020000 and y > 20000):
+            in_geom = True
+            iceArea = 1.0
+            iceVolume = 1.0
+
     elif (geomType == 'disks'):
         if ((x-0.25)*(x-0.25)+(y-0.25)*(y-0.25) < 0.04 or
             (x-0.75)*(x-0.75)+(y-0.75)*(y-0.75) < 0.04):


### PR DESCRIPTION
Remove plots in decohesion testcases related to displaying crack tracking info.
Remove now deleted arrays for crack tracking from streams files.

Add a decohesion testing configuration for decohesion.
Modify MPM testcases (ridging and standard physics) to have a decohesion block in their namelist files.
Add another MPM/decohesion testcase similar to the BBM testcase in https://doi.org/10.5194/egusphere-2024-3521.

See concomitant code modifications: https://github.com/MPAS-Seaice-MPM-Project/MPAS-Seaice-MPM/pull/114